### PR TITLE
ROS_DOMAIN_ID default to 1 if hostname is not set up according to rob…

### DIFF
--- a/robot/docker/.bashrc
+++ b/robot/docker/.bashrc
@@ -177,8 +177,12 @@ export ROBOT_NAME=$(echo "$container_name" | sed "s#/$CONTAINER_PREFIX##" | sed 
 export ROS_DOMAIN_ID=$(echo "$ROBOT_NAME" | awk -F'_' '{print $NF}')
 
 if [ "$ROBOT_NAME" == "null" ]; then
-    num=$(hostname | awk -F'-' '{print $2}') # get number from hostname
-    num=$((num)) #remove leading zeros
+    num=$(hostname | awk -F'-' '{print $2}') # Get number from hostname
+    if [ -z "$num" ]; then  # Check if num is empty
+        num=1  # Default to 1 if no number is found in the hostname
+    else
+        num=$((num))  # Remove leading zeros
+    fi
     export ROBOT_NAME="robot_$num"
     export ROS_DOMAIN_ID=$num
 fi


### PR DESCRIPTION
This is for docker setup on ORIN/ ORIN NX. ROS_DOMAIN_ID defaults to 1 if the hostname is not set up according to the robot index.

Since this is only for the jetson branch, docs will be in another pull request to the main branch.