### PR TITLE
Jkeller/robot dockerfile bugfix

### DIFF
--- a/robot/docker/Dockerfile.robot
+++ b/robot/docker/Dockerfile.robot
@@ -110,7 +110,7 @@ RUN apt remove -y libopenvdb*; \
     cd ..; rm -rf /opt/openvdb/build
 
 # Add ability to SSH
-RUN apt-get update && apt-get install -y openssh-server libimath-dev
+RUN apt-get update && apt-get install -y openssh-server
 RUN mkdir /var/run/sshd
 
 # Password is airstack

--- a/robot/docker/Dockerfile.robot
+++ b/robot/docker/Dockerfile.robot
@@ -1,6 +1,5 @@
 # either ubuntu:22.04 or l4t. ubuntu:22.04 is default
 ARG BASE_IMAGE
-ARG REAL_ROBOT=false
 FROM ${BASE_IMAGE:-ubuntu:22.04}
 
 # from https://github.com/athackst/dockerfiles/blob/main/ros2/humble.Dockerfile
@@ -122,8 +121,10 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 
 EXPOSE 22
 
-RUN if [ "$REAL_ROBOT" = "true" ]; then \
+ARG REAL_ROBOT=false
+RUN if [ "$REAL_ROBOT"  = "true" ]; then \
   apt-get update && apt-get install -y libimath-dev; \
+  echo "Condition is true"; \
 else \
   echo "Condition is false"; \
 fi

--- a/robot/docker/Dockerfile.robot
+++ b/robot/docker/Dockerfile.robot
@@ -1,5 +1,6 @@
 # either ubuntu:22.04 or l4t. ubuntu:22.04 is default
 ARG BASE_IMAGE
+ARG REAL_ROBOT=false
 FROM ${BASE_IMAGE:-ubuntu:22.04}
 
 # from https://github.com/athackst/dockerfiles/blob/main/ros2/humble.Dockerfile
@@ -120,7 +121,12 @@ RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
 EXPOSE 22
-    
+
+RUN if [ "$REAL_ROBOT" = "true" ]; then \
+  apt-get update && apt-get install -y libimath-dev; \
+else \
+  echo "Condition is false"; \
+fi
 
 # Cleanup. Prevent people accidentally doing git commits as root in Docker
 RUN apt purge git -y \

--- a/robot/docker/Dockerfile.robot
+++ b/robot/docker/Dockerfile.robot
@@ -123,10 +123,14 @@ EXPOSE 22
 
 ARG REAL_ROBOT=false
 RUN if [ "$REAL_ROBOT"  = "true" ]; then \
+  # Put commands here that should run for the real robot but not the sim
+  
+  echo "REAL_ROBOT is true"; \
   apt-get update && apt-get install -y libimath-dev; \
-  echo "Condition is true"; \
 else \
-  echo "Condition is false"; \
+  # Put commands here that should be run for the sim but not the real robot
+  
+  echo "REAL_ROBOT is false"; \
 fi
 
 # Cleanup. Prevent people accidentally doing git commits as root in Docker

--- a/robot/docker/Dockerfile.robot_real
+++ b/robot/docker/Dockerfile.robot_real
@@ -1,7 +1,0 @@
-INCLUDE+ Dockerfile.robot
-
-RUN apt-get update && apt-get install -y libimath-dev
-
-RUN apt autoremove -y \
-    && apt clean -y \
-    && rm -rf /var/lib/apt/lists/*

--- a/robot/docker/Dockerfile.robot_real
+++ b/robot/docker/Dockerfile.robot_real
@@ -1,0 +1,7 @@
+INCLUDE+ Dockerfile.robot
+
+RUN apt-get update && apt-get install -y libimath-dev
+
+RUN apt autoremove -y \
+    && apt clean -y \
+    && rm -rf /var/lib/apt/lists/*

--- a/robot/docker/docker-compose.yaml
+++ b/robot/docker/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
       dockerfile: ./Dockerfile.robot
       args:
         BASE_IMAGE: nvcr.io/nvidia/l4t-jetpack:r36.4.0
-        REAK_ROBOT: true
+        REAL_ROBOT: true
       tags:
         - *l4t_image
     # we use tmux send-keys so that the session stays alive

--- a/robot/docker/docker-compose.yaml
+++ b/robot/docker/docker-compose.yaml
@@ -47,6 +47,7 @@ services:
       dockerfile: ./Dockerfile.robot
       args:
         BASE_IMAGE: nvcr.io/nvidia/l4t-jetpack:r36.4.0
+        REAK_ROBOT: true
       tags:
         - *l4t_image
     # we use tmux send-keys so that the session stays alive


### PR DESCRIPTION
# Sim Robot Dockerfile Bug Fix

The package libimath-dev had to be installed on the Jetsons to build the code. When this package was installed in the sim robot docker image, it had a side effect of automatically removing some necessary ros2 packages and some other packages which were causing the colcon build to fail. I added an argument and if statement to the dockerfile so that we can run sim specific and real robot specific commands during the build.