### PR TITLE
Add Docker build GitHub Action workflow

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # This top-level .env file under AirStack/ defines variables that are propagated through docker-compose.yaml
 PROJECT_NAME="airstack"
-PROJECT_VERSION="1.1.0"
+PROJECT_VERSION="0.11.0"
 # can replace with your docker hub username
 PROJECT_DOCKER_REGISTRY="airlab-storage.andrew.cmu.edu:5001/shared"
 DEFAULT_ISAAC_SCENE="omniverse://airlab-storage.andrew.cmu.edu:8443/Projects/AirStack/fire_academy.scene.usd"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,51 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/Dockerfile'
+      - '**/docker-compose.yml'
+      - '**/docker-compose.yaml'
+
+jobs:
+  build-x86:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build and push x86-64 images
+        uses: mr-smithers-excellent/docker-build-push@v6
+        with:
+          image: airstack
+          registry: ghcr.io
+          username: ${{ secrets.AIRLAB_DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.AIRLAB_DOCKER_REGISTRY_PASSWORD }}
+          addLatest: true
+          enableBuildKit: true
+          platform: linux/amd64
+
+  build-l4t:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push L4T robot image
+        uses: mr-smithers-excellent/docker-build-push@v6
+        with:
+          image: airstack-robot-l4t
+          registry: ghcr.io
+          username: ${{ secrets.AIRLAB_DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.AIRLAB_DOCKER_REGISTRY_PASSWORD }}
+          addLatest: true
+          enableBuildKit: true
+          multiPlatform: true
+          platform: linux/arm64
+          directory: .
+          dockerfile: docker/robot/Dockerfile.l4t


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that:

1. Automatically builds Docker images when Dockerfile or docker-compose files change
2. Builds x86-64 images for regular services
3. Builds ARM64 images for the L4T robot service
4. Uses AIRLAB Docker registry credentials for authentication

To make this work:
1. Add `AIRLAB_DOCKER_REGISTRY_USERNAME` secret to repository
2. Add `AIRLAB_DOCKER_REGISTRY_PASSWORD` secret to repository