### PR TITLE
modified docker files to make the sitl gps initialize faster

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # This top-level .env file under AirStack/ defines variables that are propagated through docker-compose.yaml
 PROJECT_NAME="airstack"
-PROJECT_VERSION="0.11.0"
+PROJECT_VERSION="0.12.0"
 # can replace with your docker hub username
 PROJECT_DOCKER_REGISTRY="airlab-storage.andrew.cmu.edu:5001/shared"
 DEFAULT_ISAAC_SCENE="omniverse://airlab-storage.andrew.cmu.edu:8443/Projects/AirStack/fire_academy.scene.usd"

--- a/robot/docker/Dockerfile.robot
+++ b/robot/docker/Dockerfile.robot
@@ -21,11 +21,12 @@ RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
   && dpkg-reconfigure --frontend noninteractive tzdata \
   && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get -y upgrade \
+RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install common programs
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    emacs \
     curl \
     gnupg2 \
     lsb-release \
@@ -38,7 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN sudo add-apt-repository universe \
   && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null \
-  && apt-get update && apt upgrade -y && apt-get install -y --no-install-recommends \
+  && apt-get update -y && apt-get install -y --no-install-recommends \
     ros-humble-desktop \
     python3-argcomplete \
   && rm -rf /var/lib/apt/lists/*

--- a/simulation/isaac-sim/docker/Dockerfile.isaac-ros
+++ b/simulation/isaac-sim/docker/Dockerfile.isaac-ros
@@ -2,89 +2,65 @@ ARG ISAAC_VERSION="4.2.0"
 # expects context to be the root of the repository, i.e. AirStack/. this is so we can access AirStack/ros_ws/
 FROM nvcr.io/nvidia/isaac-sim:${ISAAC_VERSION}
 ARG ISAAC_VERSION
-
 WORKDIR /isaac-sim
 
+# isaac's ros2 launch run_isaacsim.launch.py hardcodes to search in this path, so we have to put the executables here
+RUN mkdir -p /root/.local/share/ov/pkg/
+RUN ln -s /isaac-sim /root/.local/share/ov/pkg/isaac-sim-4.2.0
 # allows us to run isaac-sim as root
 ENV OMNI_KIT_ALLOW_ROOT=1
 
-# from https://github.com/athackst/dockerfiles/blob/main/ros2/humble.Dockerfile
-ENV DEBIAN_FRONTEND=noninteractive
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends tzdata && \
+    rm -rf /var/lib/apt/lists/*
 
-# Install language
-RUN apt-get update && apt-get install -y \
-  locales \
-  && locale-gen en_US.UTF-8 \
-  && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
-  && rm -rf /var/lib/apt/lists/*
-ENV LANG=en_US.UTF-8
-
-# Install timezone
-RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
-  && export DEBIAN_FRONTEND=noninteractive \
-  && apt-get update \
-  && apt-get install -y tzdata \
-  && dpkg-reconfigure --frontend noninteractive tzdata \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get -y upgrade \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install common programs
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
+# install packages
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    dirmngr \
     gnupg2 \
-    lsb-release \
-    sudo \
-    software-properties-common \
-    wget \
+    unzip \
+    tmux \
     && rm -rf /var/lib/apt/lists/*
 
-# Install ROS2
-RUN sudo add-apt-repository universe \
-  && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null \
-  && apt-get update && apt upgrade -y && apt-get install -y --no-install-recommends \
-    ros-humble-desktop \
-    python3-argcomplete \
-  && rm -rf /var/lib/apt/lists/*
+# setup keys
+RUN set -eux; \
+       key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /usr/share/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros2-latest-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
 
+# setup sources.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2/ubuntu jammy main" > /etc/apt/sources.list.d/ros2-latest.list
+
+# setup environment
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 ENV ROS_DISTRO=humble
-ENV AMENT_PREFIX_PATH=/opt/ros/humble
-ENV COLCON_PREFIX_PATH=/opt/ros/humble
-ENV LD_LIBRARY_PATH=/opt/ros/humble/lib/x86_64-linux-gnu:/opt/ros/humble/lib
-ENV PATH=/opt/ros/humble/bin:$PATH
-ENV PYTHONPATH=/opt/ros/humble/local/lib/python3.10/dist-packages:/opt/ros/humble/lib/python3.10/site-packages
-ENV ROS_PYTHON_VERSION=3
-ENV ROS_VERSION=2
-ENV ROS_AUTOMATIC_DISCOVERY_RANGE=SUBNET
-ENV DEBIAN_FRONTEND=
 
-# ========================
-# Install dev tools
-RUN apt update && apt install -y \
-    vim nano wget curl tree \
-    cmake build-essential \
-    less htop jq \
+# Install ROS2 packages
+RUN apt update && apt install -y --no-install-recommends curl emacs vim nano tmux gdb xterm tree less htop jq \
+    cmake \
+    git \
+    ros-humble-desktop \
+    ros-dev-tools \
     python3-pip \
     python3-rosdep \
-    tmux \
-    gdb
-
-# Install any additional ROS2 packages
-RUN apt update -y && apt install -y \
-    ros-dev-tools \
-    ros-humble-mavros \ 
     ros-humble-tf2* \
+    ros-humble-mavros \
+    ros-humble-ackermann-msgs \
     ros-humble-topic-tools \
     ros-humble-grid-map \
     ros-humble-domain-bridge \
-    ros-humble-ackermann-msgs \
     libcgal-dev \
     python3-colcon-common-extensions
 
 RUN /opt/ros/humble/lib/mavros/install_geographiclib_datasets.sh
-
 
 RUN /isaac-sim/python.sh -m pip install git+https://github.com/dronekit/dronekit-python#egg=dronekit
 RUN pip install PyYAML mavproxy tmuxp scipy


### PR DESCRIPTION
modified docker files to make the sitl gps initialize faster. This is similar to the changes made in #52. The main thing I changed was getting rid of the adding --no-install-recommends, removing apt upgrades, and reverting to the old way of installing ros2.