### PR TITLE
Implement git hook for Docker image tagging with git commit hash

### DIFF
--- a/git-hooks/README.md
+++ b/git-hooks/README.md
@@ -8,6 +8,8 @@ This directory contains git hooks used in the AirStack repository.
 
 The pre-commit hook automatically updates the `DOCKER_IMAGE_TAG` in the `.env` file with the current git commit hash whenever Docker-related files (Dockerfile or docker-compose.yaml) are modified. It also adds a comment indicating that the value is auto-generated from the git commit hash.
 
+This ensures that Docker images are always tagged with the exact commit they were built from, eliminating version conflicts between parallel branches.
+
 ### Installation
 
 To install the hooks:


### PR DESCRIPTION
This PR implements a git hook that automatically updates the DOCKER_IMAGE_TAG in the .env file with the current git commit hash whenever Docker-related files (Dockerfile or docker-compose.yaml) are modified.

**Changes:**

1. Renamed PROJECT_VERSION to DOCKER_IMAGE_TAG in the .env file
2. Created a pre-commit hook that updates DOCKER_IMAGE_TAG with the git commit hash
3. Updated all docker-compose.yaml files to use the new variable name
4. Added a comment to indicate that the value is auto-generated

This approach eliminates version conflicts between parallel branches by ensuring Docker images are tagged with the exact commit they were built from.