### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ Robot
 
 AirStack is designed with modularity in mind, making it straightforward to extend or replace components. The development workflow is centered around Docker containers for consistent environments.
 
-For detailed development guidelines, see the [Developer Guide](https://docs.theairlab.org/docs/development/).
+For detailed development guidelines, see the [Developer Guide](https://docs.theairlab.org/main/docs/development/).
 
 ## 📚 Documentation
 
-Comprehensive documentation is available at [https://docs.theairlab.org/docs/](https://docs.theairlab.org/docs/)
+Comprehensive documentation is available at [https://docs.theairlab.org/main/docs/](https://docs.theairlab.org/main/docs/)
 
 The documentation covers:
 - Getting started guides
@@ -149,7 +149,7 @@ The documentation covers:
 
 ## 🤝 Contributing
 
-We welcome contributions to AirStack! Please see our [Contributing Guidelines](https://docs.theairlab.org/docs/development/contributing/) for more information.
+We welcome contributions to AirStack! Please see our [Contributing Guidelines](https://docs.theairlab.org/main/docs/development/contributing/) for more information.
 
 ## 📄 License
 


### PR DESCRIPTION
This pull request updates several documentation links in the `README.md` file to point to the correct paths in the updated documentation structure.

Documentation updates:

* Updated the link to the Developer Guide to point to `https://docs.theairlab.org/main/docs/development/` for accuracy. (`README.md`, [README.mdL136-R140](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L136-R140))
* Updated the link to the main documentation site to `https://docs.theairlab.org/main/docs/` for consistency with the new structure. (`README.md`, [README.mdL136-R140](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L136-R140))
* Updated the link to the Contributing Guidelines to `https://docs.theairlab.org/main/docs/development/contributing/` to match the new documentation hierarchy. (`README.md`, [README.mdL152-R152](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L152-R152))Fixed the broken links on the main page.