### PR TITLE
Fixed double isaac-sim launch issue

### DIFF
--- a/simulation/isaac-sim/docker/docker-compose.yaml
+++ b/simulation/isaac-sim/docker/docker-compose.yaml
@@ -95,7 +95,7 @@ services:
     container_name: isaac-sim-gui
     # don't spawn by default, only when you want to use the GUI
     profiles: !override
-      - ""
+      - isaac-sim-gui
     command: >
       bash -c "tmux new -d -s isaac; 
         tmux send-keys -t isaac '/isaac-sim/runapp.sh' ENTER; 


### PR DESCRIPTION
# Pull Request Title

## What does this pull request do?

Fixes the issue noticed with launching the isaac-sim window twice with `airstack up`

## How did you implement it?

Specified specific allowed profiles in simulation/isaac-sim/docker/docker-compose.yaml file for the isaac-sim-gui container.

## Testing
**How do you run the tests?**

`airstack up`
should launch everything as normal (without the additional isaac-sim-gui window)

`airstack up isaac-sim-gui`
Should only launch the specific isaac-sim-gui container.