### PR TITLE
fix(isaac-sim): pegasus drone retains PX4 state across Stop/Play

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ PROJECT_NAME="airstack"
 # If you've run ./airstack.sh setup, then this will auto-generate from the git commit hash every time a change is made 
 # to a Dockerfile or docker-compose.yaml file. Otherwise this can also be set explicitly to make a release version.
 # auto-generated from git commit hash
-VERSION="0.19.0-alpha.1"
+VERSION="0.19.0-alpha.2"
 # Choose "dev" or "prebuilt". "dev" is for mounted code that must be built live. "prebuilt" is for built ros_ws baked into the image
 DOCKER_IMAGE_BUILD_MODE="dev"  
 # Where to push and pull images from. Can replace with your docker hub username if using docker hub.


### PR DESCRIPTION
# What features did you add and/or bugs did you address?
Bumps the `PegasusSimulator` submodule to [`fe8b5a10`](https://github.com/castacks/PegasusSimulator/commit/fe8b5a101857f2cda290b9b677b3a95c4cca6b09), which fixes a bug where pressing **Stop** and then **Play** in Isaac Sim caused the drone's props to spin and veer off toward its previous PX4 setpoint instead of resetting cleanly.

No AirStack-side code changes — just a submodule pointer update and a version bump.

# How did you implement it?
All fixes live in the submodule commit. Summary of what changed there:

1. **PX4 was not actually killed on Stop.** `Popen.kill()` only targeted the parent and never `wait()`ed, so helper threads/children survived and kept talking to the simulator on the next Play. PX4 is now launched with `start_new_session=True` and the whole process group is killed via `SIGTERM -> wait -> SIGKILL -> wait` in `kill_px4()`.

2. **Leaked physics callbacks reapplied stale rotor speeds.** After Stop, callbacks could still read the backend's last commanded rotor speeds and apply them as thrust. `_rotor_data` is now zeroed on `backend.stop()`, and `backend.update()` early-returns when not running / no connection, so any stale callback applies zero thrust.

3. **Tearing down and rebuilding the multirotor caused `[simulator_mavlink] poll timeout` on the second Play.** Isaac's `add_physics_callback` does not reliably overwrite an existing key, so the new multirotor's sensor callbacks failed to register and PX4 never received HIL_SENSOR. The multirotor and its physics callbacks are now kept alive across Stop/Play cycles; the per-vehicle `sim_start_stop` callback drives `backend.start()/stop()` (which relaunches a clean PX4 process each Play).

See the submodule commit message for the full rationale.

# How do you run and use it?
```bash
# From the repo root, ensure the submodule is at the new pointer
git submodule update --init --recursive

# Bring up Isaac Sim with Pegasus (single drone is fine to reproduce)
airstack up isaac-sim
```

Then in the Isaac Sim UI:
1. Press **Play** — drone spawns and PX4 connects.
2. Press **Stop**.
3. Press **Play** again.

**Before this fix:** props spin immediately and the drone drifts toward the previous setpoint; PX4 logs may show `[simulator_mavlink] poll timeout`.

**After this fix:** drone sits idle with zero thrust, PX4 reconnects cleanly, and behavior is identical to the first Play.

# Testing with PyTest
No new pytests added — this is a submodule pointer bump for a UI-driven Stop/Play interaction that the current `tests/` harness does not exercise (the takeoff/hover/land test runs a single Play cycle).

Existing relevant suites should continue to pass:
```bash
airstack test -m liveliness --sim isaacsim --num-robots 1 --stress-iterations 1 -v
airstack test -m takeoff_hover_land --sim isaacsim --num-robots 1 -v
```

Expected: same pass/fail status as develop.

# Documentation
- Was mkdocs.yml updated? **n** — submodule-only change, no new user-facing surface.
- Newcomer reproduction steps are in the "How do you run and use it?" section above.
- No new visual media; the fix is observable via the manual repro above.

# Versioning
Bumped `.env` `VERSION` from `0.19.0-alpha.1` to `0.19.0-alpha.2` (bug fix on the current alpha line per the template).