### PR TITLE
Fix/camera init

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ PROJECT_NAME="airstack"
 # If you've run ./airstack.sh setup, then this will auto-generate from the git commit hash every time a change is made 
 # to a Dockerfile or docker-compose.yaml file. Otherwise this can also be set explicitly to make a release version.
 # auto-generated from git commit hash
-VERSION="0.19.0-alpha.3"
+VERSION="0.19.0-alpha.4"
 # Choose "dev" or "prebuilt". "dev" is for mounted code that must be built live. "prebuilt" is for built ros_ws baked into the image
 DOCKER_IMAGE_BUILD_MODE="dev"  
 # Where to push and pull images from. Can replace with your docker hub username if using docker hub.

--- a/robot/ros_ws/src/perception/perception_bringup/launch/perception.launch.xml
+++ b/robot/ros_ws/src/perception/perception_bringup/launch/perception.launch.xml
@@ -50,6 +50,7 @@
                     to="/$(env ROBOT_NAME)/perception/stereo_image_proc/disparity" />
 
                 <param name="speckle_size" value="300" />
+                <param name="approximate_sync" value="true" />
             </node>
             <!-- Point Cloud Generation -->
             <node
@@ -69,6 +70,7 @@
                 <!-- outputs -->
                 <remap from="disparity" to="/$(env ROBOT_NAME)/perception/stereo_image_proc/disparity" />
                 <remap from="points2" to="/$(env ROBOT_NAME)/perception/stereo_image_proc/point_cloud" />
+                <param name="approximate_sync" value="true" />
             </node>
         </group>
 


### PR DESCRIPTION
I found the issue causing the drone to act stuck. It was cause the drone camera was being launched in mono and not stereo so droan_gl was failing. I did 15 multi-agent runs and none of them failed vs previously when testing for raven-multi i had over 50% failure rate.

In this file below which part of isaac-sim it'll default to mono if it doesn't get info from both right and left camera
/isaac-sim/exts/isaacsim.ros2.bridge/isaacsim/ros2/bridge/ogn/python/nodes/OgnROS2CameraInfoHelper.py

  is_stereo = False                              # ← set: default mono
  if not db.inputs.renderProductPath:            # left retry-guard
      db.per_instance_state.initialized = False
      return False
  if db.inputs.renderProductPathRight:           # ← set: flips True IF right input is populated
      is_stereo = True
  ...
  if is_stereo:                                  # ← used: gate for the whole right-eye branch
      camera_info_right, camera_right = read_camera_info(db.inputs.renderProductPathRight)
      ... stereoRectify ...
      add_camera_info_writer(... topicNameRight ...)   # right writer only created here
  add_camera_info_writer(... topicName ...)            # left writer always created

in  simulation/isaac-sim/extensions/PegasusSimulator/extensions/pegasus.simulator/pegasus/simulator/ogn/api/spawn_zed_camera.py
The current line
  (f"{nodes['playback']}.outputs:tick",  f"{nodes['info_helper']}.inputs:execIn"),

  - SOURCE = playback.outputs:tick — the OnPlaybackTick node's tick output, which fires once every simulation frame while the sim is playing.
  - DESTINATION = info_helper.inputs:execIn — the camera-info-helper's "run now" trigger.
  The problem: the two IsaacCreateRenderProduct nodes are wired to that same playback.tick (lines 222–223), so all three are triggered by one pulse
  with no guaranteed order between them:

  playback.tick ──┬──► left_create_rp.execIn     (builds LEFT render product)
                  ├──► right_create_rp.execIn     (builds RIGHT render product)
                  └──► info_helper.execIn          (reads both — but can run before RIGHT is ready)

  On the tick where the info-helper commits its one-time init, the right render product often isn't produced yet → db.inputs.renderProductPathRight is
  empty → is_stereo = False → right writer never created.

  The new line
  (f"{right_nodes['create_rp']}.outputs:execOut",  f"{nodes['info_helper']}.inputs:execIn"),

  - SOURCE = right_create_rp.outputs:execOut — a node's execOut fires after that node's compute() finishes. So this pulse fires only after the right
  render product has been created and its renderProductPath output is populated.
  - DESTINATION = same info_helper.inputs:execIn.
  playback.tick ──┬──► left_create_rp.execIn
                  └──► right_create_rp.execIn ──(execOut)──► info_helper.execIn
                                                              (now runs AFTER right product exists)

  Now when compute() reads db.inputs.renderProductPathRight, it's already valid → the Isaac node's own if db.inputs.renderProductPathRight: is_stereo =
  True evaluates True → right writer is built. 