### PR TITLE
Modular AirStack 1/9: wiring observability, module manifest, reusable module CI

### DIFF
--- a/.agents/skills/create-module/SKILL.md
+++ b/.agents/skills/create-module/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: create-module
+description: Create a new AirStack module repository by hand — author the thin module.yaml manifest, lay out colcon packages with canonical-default launch args (never remaps), add test_stack/ and CI, and validate with tools/validate_module.py. Use when packaging a capability (planner, estimator, sim extension, vehicle data) as a standalone module repo per RFC #379.
+license: Apache-2.0
+metadata:
+  author: AirLab CMU
+  repository: AirStack
+---
+
+# Skill: Create an AirStack Module Repo
+
+## When to Use
+
+Creating a **new AirStack module repo** — a thin, standalone repository that
+distributes an optional capability (a planner, state estimator, world model, Isaac
+Sim extension, vehicle definition, …) without forking AirStack. Defined by
+[RFC #379](https://github.com/castacks/AirStack/discussions/379) §2 (manifest) and
+[RFC #385](https://github.com/castacks/AirStack/discussions/385) §2 (repo anatomy).
+
+Not this skill: adding a trunk-resident package (use `add-ros2-package`), or wiring
+an existing module into a bringup (use `integrate-module-into-layer`).
+
+> **Status:** `airstack module create` scaffolding arrives in a later phase. Until
+> then this skill documents the **by-hand procedure**; only the manifest schema and
+> validator (`tools/validate_module.py`) exist today.
+
+## Module Repo Anatomy (RFC #385 §2)
+
+A module is a *thin* repo: ordinary colcon packages, a small manifest carrying deps
+and identity only, and a `test_stack/` that is both its CI target and its living
+install documentation.
+
+```
+my-module/
+├── module.yaml                  # the thin manifest — deps, identity, tests; NO wiring
+├── my_module/                   # ordinary colcon package(s)
+│   ├── package.xml              # rosdep keys live here (dep tier 1)
+│   ├── src/  config/  test/     # co-located unit tests, standard colcon convention
+│   └── launch/
+│       └── my_module.launch.xml # topic args DEFAULT to canonical names; never remaps
+├── test_stack/                  # reference-stack copy with this module wired in
+│   ├── modules.repos            # PINNED to tags/commits — never branches
+│   ├── launch/stack.launch.xml  # the ONE place this module is wired
+│   ├── docker-compose.yaml
+│   ├── wiring.md                # generated in CI from the running graph
+│   └── README.md
+├── Dockerfile.module            # optional dep tier 2 — against ARG BASE_IMAGE only
+├── .github/workflows/
+│   └── ci.yml                   # ~10 lines: uses castacks/AirStack/.github/workflows/
+│                                #   module-system-tests.yml@vX.Y.Z (later phase)
+└── README.md
+```
+
+## The Manifest (`module.yaml`)
+
+Schema + full field reference: [`common/module_schema/`](../../../common/module_schema/README.md).
+Summary:
+
+- **Required:** `name` (snake_case), `description`, `maintainer` (email),
+  `license`, `type` (`isaac_extension` | `ros_package` | `data` | `platform`),
+  `airstack_compat` (semver range vs trunk `.env` `VERSION`, e.g.
+  `">=0.19.0 <0.21.0"` — never a branch name), `targets`
+  (non-empty: `robot` | `gcs` | `isaac-sim` | `ms-airsim`).
+- **Optional:** `deps` `{apt, pip}`, `dockerfile` (path ending
+  `Dockerfile.module`), `overlay_image`, `compose`, `assets`
+  (`[{url (https), sha256, dest}]` — no Git LFS), `docs`, `foxglove`, `hooks`
+  (`host_setup`: idempotent, no sudo, writes only inside the module checkout),
+  `tests` (`packages` + `marks` from the known mark set).
+- **Deliberately absent: wiring.** No slot, role, or topic metadata — unknown keys
+  are rejected. A module's interface is its launch file's declared args
+  (`ros2 launch <pkg> <file> --show-args`).
+
+Minimal working example: [`tests/fixtures/modules/hello_module/module.yaml`](../../../tests/fixtures/modules/hello_module/module.yaml).
+
+## The Canonical-Defaults Launch Rule
+
+The one interface convention that does the plug-and-play work (RFC #379 §2, §4):
+
+- Expose **every topic endpoint as a launch arg**, and **default it to the
+  canonical name** from the interface conventions spec (today:
+  `docs/robot/autonomy/integration_checklist.md`).
+- **NEVER put `<remap>` in a module launch file**, and never hardcode a topic in
+  node code. All cross-module remaps live in the *stack's* entry launch file —
+  the single-locus wiring rule.
+
+```xml
+<launch>
+  <!-- every endpoint is an arg; the default IS the canonical name -->
+  <arg name="odom_out" default="/$(env ROBOT_NAME)/odometry"
+       description="Output odometry topic" />
+  <node pkg="my_module" exec="my_node" name="my_node" output="screen">
+    <param from="$(find-pkg-share my_module)/config/my_module.yaml" allow_substs="true" />
+    <remap from="odometry" to="$(var odom_out)" />
+  </node>
+</launch>
+```
+
+(The `<remap>` *inside* the node block binds the node's internal name to the
+declared arg — that is the mechanism, not a cross-module rewire. What is forbidden
+is remapping other modules' topics or overriding canonical names in module launch
+files: in a conventional stack, including the module must require **zero** remaps,
+so only deviations appear in stack files.)
+
+## Steps (by hand, until `airstack module create` lands)
+
+1. Create the repo with the anatomy above; write `module.yaml` first.
+2. Write the package(s) following `add-ros2-package` conventions (package.xml
+   format 3, co-located `test/`).
+3. Author the module launch file under the canonical-defaults rule.
+4. Validate:
+
+   ```bash
+   python3 tools/validate_module.py path/to/my-module
+   ```
+
+   Exit 0 and `{"valid": true, "errors": []}` on stdout is the gate. Dir mode also
+   checks that declared `dockerfile`/`compose`/`hooks`/`docs` paths exist and warns
+   when `tests.packages` entries match no directory.
+5. Copy a trunk reference stack into `test_stack/` and wire the module in its
+   `stack.launch.xml` (reference stacks land in a later phase; until then model it
+   on the bringup you tested against).
+6. Add `ci.yml` calling the reusable `module-system-tests.yml` workflow (later
+   phase) with pinned `airstack_ref` and the marks for your module category
+   (RFC #379 §5: global planner → `waypoint_flight`,`autonomy`; state estimator →
+   `liveliness`,`sensors`,`takeoff_hover_land`; world model/perception →
+   `liveliness`,`sensors`; sim extension → `liveliness`).
+
+## References
+
+- Manifest schema + validator: [`common/module_schema/`](../../../common/module_schema/README.md)
+- Fixture module: [`tests/fixtures/modules/hello_module/`](../../../tests/fixtures/modules/hello_module/)
+- Contract tests: [`tests/meta/test_module_manifest_contract.py`](../../../tests/meta/test_module_manifest_contract.py)
+- RFC #379 (design), RFC #385 (directory atlas)
+- Related skills: [add-ros2-package](../add-ros2-package), [write-launch-file](../write-launch-file), [run-system-tests](../run-system-tests)

--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ PROJECT_NAME="airstack"
 # If you've run ./airstack.sh setup, then this will auto-generate from the git commit hash every time a change is made 
 # to a Dockerfile or docker-compose.yaml file. Otherwise this can also be set explicitly to make a release version.
 # auto-generated from git commit hash
-VERSION="0.19.0-alpha.18"
+VERSION="0.20.0-alpha.1"
 # Choose "dev" or "prebuilt". "dev" is for mounted code that must be built live. "prebuilt" is for built ros_ws baked into the image
 DOCKER_IMAGE_BUILD_MODE="dev"  
 # Where to push and pull images from. Can replace with your docker hub username if using docker hub.

--- a/.github/orchestrator/README.md
+++ b/.github/orchestrator/README.md
@@ -150,6 +150,31 @@ osmo workflow list --name gha-runner- --pool airstack-ci
 osmo workflow list --name gha-runner- --pool airstack-ci --status RUNNING PENDING WAITING
 ```
 
+## Module repos
+
+Module repos (`asm_*`) that call trunk's reusable
+[`module-system-tests.yml`](https://github.com/castacks/AirStack/blob/main/.github/workflows/module-system-tests.yml) with the
+default `runs-on: [self-hosted, airstack-ephemeral]` queue jobs **in their own
+repo**, and the orchestrator polls exactly one `repo:` per instance. To add an
+`asm_` repo to the poll list, run a second orchestrator instance against it:
+
+1. **Extend the PAT.** The fine-grained GitHub PAT must also cover the module
+   repo with `Actions: read/write` + `Administration: read/write` (JIT runner
+   registration is per-repo). Reuse the existing PAT file if it covers the
+   repo, else stage a second one.
+2. **Copy the config.** `/etc/airstack-orchestrator/config.yaml` →
+   `config-asm-<name>.yaml` with `repo: "castacks/asm_<name>"` and a
+   **distinct `workflow_name_prefix`** (e.g. `gha-runner-asm<name>-`) so the
+   two instances' orphan sweeps don't cancel each other's OSMO workflows.
+3. **Run a second service instance** pointing at the new config and its own
+   state file (copy `airstack-orchestrator.service`, adjust `ExecStart`'s
+   `--config` and `--state`, e.g. `--state /var/lib/airstack-orchestrator/state-asm-<name>.json`).
+
+First-party only: the reusable workflow refuses callers outside the castacks
+org, mirroring the fork-PR block. Org-level polling across registered repos
+(one instance, many repos) is the RFC #379 Phase 4 replacement for this
+per-repo setup.
+
 ## Operational notes
 
 - **State file**: `/var/lib/airstack-orchestrator/state.json` is the in-flight job tracker (`job_id → workflow_id`). Wiping it triggers an orphan sweep on the next reap iteration — active `gha-runner-*` workflows will be cancelled. Don't wipe it while jobs are mid-flight unless that's what you want.

--- a/.github/workflows/module-system-tests.yml
+++ b/.github/workflows/module-system-tests.yml
@@ -1,0 +1,548 @@
+name: Module System Tests
+
+# Reusable system-test workflow for AirStack module repos (RFC #379 §5).
+#
+# A module repo (asm_*) calls this workflow to run trunk's existing system-test
+# suite — unchanged — against a pinned AirStack ref with the module added to
+# the checkout. The module repo never copies a test.
+#
+#   jobs:
+#     system-tests:
+#       uses: castacks/AirStack/.github/workflows/module-system-tests.yml@v0.19.0
+#       with:
+#         airstack_ref: v0.19.0     # pin and checkout ref move together
+#         marks: "build_packages or liveliness"
+#         sim: isaacsim
+#
+# First-party only: the job refuses callers outside the castacks org. External
+# modules go through the dispatch-triggered test bench (RFC #379 §5, Phase 4).
+#
+# Registry secrets are optional. When the caller passes them (castacks org
+# secrets provide DOCKER_REGISTRY_* to org repos — the internal registry is
+# airlab-docker.andrew.cmu.edu/airstack, NOT ghcr), image prep pulls versioned
+# and floating cache tags instead of cold-building. Without them the workflow
+# still works; it just image-builds from scratch when pulls miss.
+#
+# The workflow_dispatch trigger exists so trunk maintainers can smoke-test this
+# workflow against any module repo without a caller in place:
+#
+#   gh workflow run module-system-tests.yml --repo castacks/AirStack \
+#     --ref <branch-with-this-file> \
+#     -f module_repo=castacks/asm_dfm2_disturbances -f module_ref=main \
+#     -f airstack_ref=develop -f marks="build_packages or liveliness"
+#
+# GPU runner note: with the default runs_on, the job queues for the ephemeral
+# OSMO-backed runners (.github/orchestrator/). The orchestrator polls one repo
+# per instance, so a module repo must be added to the poll list before its
+# calls can be picked up — see .github/orchestrator/README.md "Module repos".
+#
+# Docs: docs/development/module_ci.md
+
+on:
+  workflow_call:
+    inputs:
+      airstack_ref:
+        description: "Tag/branch/SHA of castacks/AirStack to test the module against. Pin it together with the workflow's own @<ref>. Must include the module CLI (airstack module add/sync)."
+        type: string
+        required: true
+      marks:
+        description: "pytest marks expression (see tests/pytest.ini). build_packages is auto-prepended when absent so code is built before launch tests run."
+        type: string
+        default: "build_packages or liveliness"
+      sim:
+        description: "Sim targets, comma-separated: isaacsim,msairsim."
+        type: string
+        default: "isaacsim"
+      num_robots:
+        description: "Robot counts, comma-separated (e.g. 1,3)."
+        type: string
+        default: "1"
+      stress_iterations:
+        description: "Iterations per (sim, num_robots) config."
+        type: string
+        default: "1"
+      stable_duration:
+        description: "Seconds for the test_stable polling window."
+        type: string
+        default: "120"
+      module_tests_dir:
+        description: "Module-relative directory of extra pytest tests, appended to the pytest paths only if it exists in the module checkout."
+        type: string
+        default: "tests"
+      runs_on:
+        description: "JSON array string parsed into runs-on."
+        type: string
+        default: '["self-hosted","airstack-ephemeral"]'
+      timeout_minutes:
+        description: "Job timeout in minutes."
+        type: number
+        default: 120
+    secrets:
+      DOCKER_REGISTRY_URL:
+        description: "Internal Docker registry host (castacks org secret; airlab-docker.andrew.cmu.edu). Optional — enables registry-cache image prep."
+        required: false
+      DOCKER_REGISTRY_USERNAME:
+        description: "Registry username (castacks org secret). Optional."
+        required: false
+      DOCKER_REGISTRY_PASSWORD:
+        description: "Registry password (castacks org secret). Optional."
+        required: false
+
+  # Trunk-maintainer smoke path: same inputs as workflow_call, plus the module
+  # repo/ref to test (workflow_call derives those from the caller instead).
+  # timeout_minutes is omitted here (workflow_dispatch caps at 10 inputs); the
+  # job falls back to 120 when it is unset.
+  workflow_dispatch:
+    inputs:
+      module_repo:
+        description: "Module repo to test (owner/name, e.g. castacks/asm_dfm2_disturbances)."
+        type: string
+        required: true
+      module_ref:
+        description: "Module ref (tag/branch/SHA)."
+        type: string
+        default: "main"
+      airstack_ref:
+        description: "Tag/branch/SHA of castacks/AirStack to test the module against."
+        type: string
+        default: "develop"
+      marks:
+        description: "pytest marks expression. build_packages is auto-prepended when absent."
+        type: string
+        default: "build_packages or liveliness"
+      sim:
+        description: "Sim targets, comma-separated: isaacsim,msairsim."
+        type: string
+        default: "isaacsim"
+      num_robots:
+        description: "Robot counts, comma-separated (e.g. 1,3)."
+        type: string
+        default: "1"
+      stress_iterations:
+        description: "Iterations per (sim, num_robots) config."
+        type: string
+        default: "1"
+      stable_duration:
+        description: "Seconds for the test_stable polling window."
+        type: string
+        default: "120"
+      module_tests_dir:
+        description: "Module-relative extra pytest dir (appended only if it exists)."
+        type: string
+        default: "tests"
+      runs_on:
+        description: "JSON array string parsed into runs-on."
+        type: string
+        default: '["self-hosted","airstack-ephemeral"]'
+
+permissions:
+  contents: read
+
+jobs:
+  module-tests:
+    name: Module System Tests
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ inputs.timeout_minutes || 120 }}
+    # Mirror the registry secrets into env so step-level `if:` expressions can
+    # check whether registry-cache mode is available — `secrets.*` itself is
+    # not addressable from `if:` expressions.
+    env:
+      DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}
+      DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+    steps:
+      # First-party policy (RFC #379 §5): org GPU runners and registry secrets
+      # never serve repos outside castacks. In a reusable workflow the github
+      # context is the CALLER's, so repository_owner is the module repo's org.
+      # External modules use the dispatch-triggered test bench when it lands
+      # (Phase 4); until then this is a hard refusal, not a degraded mode.
+      - name: Enforce first-party module policy
+        if: github.repository_owner != 'castacks'
+        run: |
+          echo "::error::module-system-tests.yml is first-party only: the calling repository must live in the castacks org (caller is '${{ github.repository }}'). External modules will be served by the dispatch-triggered test bench (RFC #379 §5); it does not exist yet."
+          exit 1
+
+      - name: Checkout AirStack (trunk under test)
+        uses: actions/checkout@v4
+        with:
+          repository: castacks/AirStack
+          ref: ${{ inputs.airstack_ref }}
+          submodules: recursive
+
+      # workflow_call: the module is the calling repo at the triggering SHA.
+      # workflow_dispatch: the module is named explicitly by inputs.
+      - name: Resolve module source
+        id: module_src
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_REPO: ${{ inputs.module_repo }}
+          DISPATCH_REF: ${{ inputs.module_ref }}
+          CALLER_REPO: ${{ github.repository }}
+          CALLER_SHA: ${{ github.sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            repo="$DISPATCH_REPO"
+            ref="${DISPATCH_REF:-main}"
+          else
+            repo="$CALLER_REPO"
+            ref="$CALLER_SHA"
+          fi
+          if [[ -z "$repo" ]]; then
+            echo "::error::No module repository resolved (module_repo input is required for workflow_dispatch)."
+            exit 1
+          fi
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "Module under test: $repo @ $ref"
+
+      - name: Checkout module under test
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.module_src.outputs.repo }}
+          ref: ${{ steps.module_src.outputs.ref }}
+          path: module-under-test
+          submodules: recursive
+
+      - name: Install test dependencies
+        # Ubuntu 24.04 marks the system Python as externally-managed (PEP 668),
+        # so `pip install` outside a venv is rejected. Use a venv and prepend
+        # its bin/ to $GITHUB_PATH so subsequent steps pick up `pytest`
+        # automatically.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends python3-venv
+          python3 -m venv .venv
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r tests/requirements.txt
+
+      - name: Validate module manifest
+        run: python3 tools/validate_module.py module-under-test
+
+      # Artifact/summary identity: the manifest name, falling back to the repo
+      # basename. Sanitized because artifact names reject several characters.
+      - name: Resolve module name
+        id: module
+        env:
+          MODULE_REPO: ${{ steps.module_src.outputs.repo }}
+        run: |
+          python3 - <<'PYEOF'
+          import os, re
+          name = ""
+          try:
+              import yaml
+              with open("module-under-test/module.yaml") as f:
+                  name = str(yaml.safe_load(f).get("name") or "")
+          except Exception:
+              pass
+          if not name:
+              name = os.environ["MODULE_REPO"].rsplit("/", 1)[-1]
+          name = re.sub(r'[^A-Za-z0-9._-]+', "-", name)
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"name={name}\n")
+          print(f"Module name: {name}")
+          PYEOF
+
+      - name: Ensure airstack.sh is executable
+        run: chmod +x airstack.sh
+
+      # Register the module with the trunk checkout via the module CLI
+      # (contract: `airstack module add <local-path>` places the module and
+      # runs its declared hooks.host_setup; `airstack module sync` materializes
+      # the overlay — ROS packages into robot/ros_ws/src/modules/, Isaac
+      # extensions onto the extension path, compose fragments into
+      # COMPOSE_FILE). `--no-hooks` is attempted first so a hook failure can't
+      # masquerade as an add failure; the fallback covers a CLI that doesn't
+      # know the flag. hooks.host_setup is then run explicitly below — the
+      # manifest schema requires hooks to be idempotent, so running it after an
+      # add that already ran it is safe.
+      - name: Add module to the AirStack checkout
+        run: |
+          ./airstack.sh module add ./module-under-test --no-hooks \
+            || ./airstack.sh module add ./module-under-test
+          ./airstack.sh module sync
+
+      - name: Run module host_setup hook (if declared)
+        run: |
+          hook="$(python3 -c "
+          import yaml
+          with open('module-under-test/module.yaml') as f:
+              m = yaml.safe_load(f) or {}
+          print((m.get('hooks') or {}).get('host_setup') or '')
+          ")"
+          if [[ -n "$hook" ]]; then
+            echo "Running hooks.host_setup: $hook (idempotent by manifest contract)"
+            (cd module-under-test && bash "$hook")
+          else
+            echo "No hooks.host_setup declared."
+          fi
+
+      - name: Create Isaac Sim omni_pass.env
+        if: contains(inputs.sim, 'isaacsim')
+        run: |
+          mkdir -p simulation/isaac-sim/docker
+          cat > simulation/isaac-sim/docker/omni_pass.env <<'EOF'
+          OMNI_USER=guest
+          OMNI_PASS=guest
+          OMNI_SERVER="omniverse://airlab-nucleus.andrew.cmu.edu/NVIDIA/Assets/Isaac/5.1"
+          ACCEPT_EULA=Y
+          OMNI_ENV_PRIVACY_CONSENT=Y
+          EOF
+
+      # Compose the pytest argv from the explicit inputs. Modeled on trunk's
+      # system-tests.yml parse block, minus the issue_comment parsing (inputs
+      # arrive structured here). Rules kept from trunk:
+      #   - build_packages is auto-prepended when marks lack it, so code is
+      #     built before launch tests run;
+      #   - marks that never launch a sim (pure build_packages) switch to
+      #     pull-only image prep so we don't bake isaac-sim for a colcon test;
+      #   - build_docker marks skip image prep entirely (those tests rebuild).
+      # Added here: the module's own pytest dir is appended when it exists,
+      # and -c tests/pytest.ini pins the config when a second path would move
+      # pytest's rootdir/inifile discovery off tests/.
+      - name: Compose pytest args
+        id: parse
+        env:
+          INPUT_MARKS: ${{ inputs.marks }}
+          INPUT_SIM: ${{ inputs.sim }}
+          INPUT_NUM_ROBOTS: ${{ inputs.num_robots }}
+          INPUT_ITERATIONS: ${{ inputs.stress_iterations }}
+          INPUT_STABLE: ${{ inputs.stable_duration }}
+          INPUT_MODULE_TESTS_DIR: ${{ inputs.module_tests_dir }}
+        run: |
+          python3 <<'PYEOF'
+          import os, shlex
+
+          marks = os.environ.get('INPUT_MARKS', '').strip() or 'build_packages or liveliness'
+          sim = os.environ.get('INPUT_SIM', '').strip() or 'isaacsim'
+
+          # When the caller specified marks without build_packages, prepend it
+          # so code is built before launch tests try to use it (same rule as
+          # trunk system-tests.yml).
+          if 'build_packages' not in marks:
+              marks = f'build_packages or {marks}'
+
+          args = ['-m', marks, '--sim', sim]
+          if (n := os.environ.get('INPUT_NUM_ROBOTS', '').strip()):
+              args.extend(['--num-robots', n])
+          if (it := os.environ.get('INPUT_ITERATIONS', '').strip()):
+              args.extend(['--stress-iterations', it])
+          if (st := os.environ.get('INPUT_STABLE', '').strip()):
+              args.extend(['--stable-duration', st])
+
+          # Marks that bring up sim/robot containers need compose images; a
+          # pure build_packages selection does not, so pull-only there (trunk's
+          # `only_packages` rule). waypoint_flight is included in the heavy set
+          # for correctness even though trunk's list predates the mark.
+          heavy = any(m in marks for m in (
+              'liveliness', 'sensors', 'takeoff_hover_land', 'autonomy',
+              'waypoint_flight', 'build_docker', 'optitrack',
+          ))
+          no_image_build = not heavy
+          skip_prep = 'build_docker' in marks
+
+          # Append the module's own pytest dir when it exists. Adding a second
+          # collection path moves pytest's rootdir to the common ancestor, so
+          # pin the config file explicitly in that case.
+          module_tests = ''
+          tests_dir = os.environ.get('INPUT_MODULE_TESTS_DIR', '').strip()
+          if tests_dir:
+              candidate = os.path.join('module-under-test', tests_dir)
+              if os.path.isdir(candidate):
+                  module_tests = candidate
+                  args.extend(['-c', 'tests/pytest.ini'])
+
+          quoted = ' '.join(shlex.quote(a) for a in args)
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'pytest_args={quoted}\n')
+              f.write(f'resolved_marks={marks}\n')
+              f.write(f'sim={sim}\n')
+              f.write(f'skip_image_prep={"true" if skip_prep else "false"}\n')
+              f.write(f'no_image_build={"true" if no_image_build else "false"}\n')
+              f.write(f'module_tests_dir={module_tests}\n')
+
+          print(f'Resolved pytest args: {quoted}')
+          print(f'Module tests dir: {module_tests or "(none)"}')
+          print(f'Skip image prep: {skip_prep}')
+          print(f'No image build (pull/retag only): {no_image_build}')
+          PYEOF
+
+      # Optional registry-cache mode. When the caller passes the registry
+      # secrets we log in to the internal Docker registry; the next step then
+      # sets AIRSTACK_REGISTRY_CACHE=1 so airstack.sh pre-pulls + uses BuildKit
+      # inline cache. When secrets are absent both steps are skipped and image
+      # prep falls back to cold builds.
+      #
+      # Read-only on purpose: AIRSTACK_REGISTRY_CACHE_PUSH stays unset here so
+      # a module run can consume the floating cache tag but never republish
+      # it. Only trunk's docker-build.yml (main/develop) writes it.
+      - name: Log in to internal Docker registry
+        id: docker_login
+        if: ${{ env.DOCKER_REGISTRY_URL != '' && env.DOCKER_REGISTRY_PASSWORD != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY_URL }}
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+
+      - name: Enable registry-cache mode
+        if: ${{ steps.docker_login.outcome == 'success' }}
+        run: echo "AIRSTACK_REGISTRY_CACHE=1" >> "$GITHUB_ENV"
+
+      - name: Disable compose image builds
+        if: ${{ steps.parse.outputs.no_image_build == 'true' }}
+        run: echo "AIRSTACK_NO_IMAGE_BUILD=1" >> "$GITHUB_ENV"
+
+      # The ephemeral runner starts with no local images. `airstack_env` in
+      # tests/conftest.py fails fast if compose images are missing, so prep
+      # them here. Profile-gated services (ms-airsim, isaac-sim) are skipped
+      # by compose unless their profile is active, so we mirror the fixture's
+      # profile selection from the sim input. Pull versioned tags, then retag
+      # floating cache_* tags onto the VERSION name (unreleased trunk refs
+      # have no versioned tag). Fall back to image-build only when pull-only
+      # mode is off. Skipped when marks contain build_docker — those tests
+      # build themselves.
+      - name: Ensure Docker images present
+        if: ${{ steps.parse.outputs.skip_image_prep != 'true' }}
+        env:
+          AIRSTACK_ROOT: ${{ github.workspace }}
+          SIM_INPUT: ${{ steps.parse.outputs.sim }}
+          NO_IMAGE_BUILD: ${{ steps.parse.outputs.no_image_build }}
+        run: |
+          profiles=desktop
+          [[ ",$SIM_INPUT," == *,msairsim,* ]] && profiles="$profiles,ms-airsim"
+          [[ ",$SIM_INPUT," == *,isaacsim,* ]] && profiles="$profiles,isaac-sim"
+          export COMPOSE_PROFILES="$profiles"
+          echo "Pulling images for COMPOSE_PROFILES=$COMPOSE_PROFILES (no_image_build=$NO_IMAGE_BUILD)"
+
+          # Pull from registry; tolerate per-image failures so we can detect
+          # what's still missing afterwards instead of aborting on the first
+          # gap. `--progress=quiet` suppresses per-layer progress; errors
+          # still surface on stderr.
+          ./airstack.sh --progress=quiet image-pull --ignore-pull-failures || true
+
+          # Versioned tags can miss (unreleased trunk refs). Seed from floating
+          # cache_* tags.
+          cache_tag="$(grep -E '^CACHE_TAG=' .env 2>/dev/null | cut -d= -f2 | tr -d '"' || true)"
+          cache_tag="${cache_tag:-cache}"
+          while IFS= read -r img; do
+            [[ -z "$img" ]] && continue
+            if docker image inspect "$img" --format '{{.Id}}' >/dev/null 2>&1; then
+              continue
+            fi
+            # Replace :v<semver>_ with :<cache_tag>_  (unpublished versioned tags)
+            cache_img="$(python3 -c "import re,sys; print(re.sub(r':v[^_]+_', f':{sys.argv[2]}_', sys.argv[1], count=1))" "$img" "$cache_tag")"
+            echo "Versioned tag missing; trying cache tag $cache_img"
+            if docker pull --quiet "$cache_img"; then
+              docker tag "$cache_img" "$img"
+              echo "Retagged $cache_img -> $img"
+            else
+              echo "Cache tag pull failed for $cache_img"
+            fi
+          done < <(docker compose -f docker-compose.yaml config --images)
+
+          missing=()
+          while IFS= read -r img; do
+            [[ -z "$img" ]] && continue
+            if ! docker image inspect "$img" --format '{{.Id}}' >/dev/null 2>&1; then
+              missing+=("$img")
+            fi
+          done < <(docker compose -f docker-compose.yaml config --images)
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "Images still missing after pull/retag:"
+            printf '  - %s\n' "${missing[@]}"
+            if [[ "$NO_IMAGE_BUILD" == "true" ]]; then
+              echo "::error::Pull-only mode (pure build_packages marks) will not image-build. Include a mark that launches the sim, or run trunk's /pytest -m build_docker once to publish cache tags."
+              exit 1
+            fi
+            echo "Falling back to image-build"
+            ./airstack.sh --progress=quiet image-build
+          else
+            echo "All required images present after pull/retag — skipping build."
+          fi
+
+      - name: Run tests
+        env:
+          AIRSTACK_ROOT: ${{ github.workspace }}
+          DISPLAY: ""
+          PYTEST_ARGS: ${{ steps.parse.outputs.pytest_args }}
+          MODULE_TESTS_DIR: ${{ steps.parse.outputs.module_tests_dir }}
+        run: |
+          # Re-split the shell-quoted args from the parse step so we forward
+          # them to pytest as a proper argv list (preserving values like
+          # `-m 'a or b'`). sys.stdout.write is intentional: print('') emits
+          # one blank line, which mapfile turns into an empty positional path
+          # and makes pytest recurse from the repository root.
+          mapfile -t ARGS < <(python3 -c "import os, shlex, sys; sys.stdout.write(''.join(f'{arg}\\n' for arg in shlex.split(os.environ['PYTEST_ARGS'])))")
+          for arg in "${ARGS[@]}"; do
+            if [[ -z "$arg" ]]; then
+              echo "::error::Refusing an empty pytest argument because it expands collection to the repository root."
+              exit 2
+            fi
+          done
+          PATHS=(tests/)
+          if [[ -n "$MODULE_TESTS_DIR" ]]; then
+            PATHS+=("$MODULE_TESTS_DIR")
+          fi
+          set +e
+          pytest "${PATHS[@]}" \
+            "${ARGS[@]}" \
+            -v -s \
+            --log-cli-level=INFO \
+            --log-cli-format='%(asctime)s [%(levelname)s] %(name)s: %(message)s' \
+            --log-cli-date-format='%H:%M:%S'
+          pytest_status=$?
+          set -e
+          if (( pytest_status != 0 )); then
+            exit "$pytest_status"
+          fi
+
+          # A successful collect-only/non-executed campaign is not a passing
+          # system test. Make that distinction visible in the job conclusion.
+          python3 <<'PYEOF'
+          import json
+          from pathlib import Path
+
+          candidates = list(Path("tests/results").glob("*/run_meta.json"))
+          if not candidates:
+              raise SystemExit("::error::pytest succeeded without run_meta.json")
+          latest = max(candidates, key=lambda path: path.stat().st_mtime)
+          outcome = json.loads(latest.read_text()).get("outcome")
+          if outcome not in {"simulation", "non_simulation"}:
+              raise SystemExit(
+                  f"::error::pytest did not execute a complete campaign ({outcome})"
+              )
+          PYEOF
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: module-test-results-${{ steps.module.outputs.name }}-${{ github.run_id }}
+          path: tests/results/
+          retention-days: 90
+
+      - name: Write job summary
+        if: always()
+        env:
+          MODULE_NAME: ${{ steps.module.outputs.name }}
+          MODULE_REPO: ${{ steps.module_src.outputs.repo }}
+          MODULE_REF: ${{ steps.module_src.outputs.ref }}
+          AIRSTACK_REF: ${{ inputs.airstack_ref }}
+          RESOLVED_MARKS: ${{ steps.parse.outputs.resolved_marks }}
+          SIM: ${{ steps.parse.outputs.sim }}
+          NUM_ROBOTS: ${{ inputs.num_robots }}
+          MODULE_TESTS_DIR: ${{ steps.parse.outputs.module_tests_dir }}
+        run: |
+          {
+            echo "## Module System Tests"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Module | \`$MODULE_NAME\` (\`$MODULE_REPO\` @ \`$MODULE_REF\`) |"
+            echo "| AirStack ref | \`${AIRSTACK_REF:-develop}\` |"
+            echo "| Marks | \`${RESOLVED_MARKS:-—}\` |"
+            echo "| Sim | \`${SIM:-—}\` |"
+            echo "| Robots | \`${NUM_ROBOTS:-1}\` |"
+            echo "| Module pytest dir | \`${MODULE_TESTS_DIR:-—}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/airstack.sh
+++ b/airstack.sh
@@ -1051,7 +1051,8 @@ function print_launch_config {
 
     # Dump for reproducibility (precursor of RFC #380's effective_config.yaml).
     # Best-effort: a read-only checkout (e.g. the tests container) skips it.
-    local run_dir="$PROJECT_ROOT/.airstack/runs/$(date +%Y-%m-%d_%H-%M-%S)"
+    # PID suffix keeps back-to-back runs within the same second in distinct dirs.
+    local run_dir="$PROJECT_ROOT/.airstack/runs/$(date +%Y-%m-%d_%H-%M-%S)_$$"
     if mkdir -p "$run_dir" 2>/dev/null && printf '%s\n' "${lines[@]}" > "$run_dir/effective_config.env" 2>/dev/null; then
         log_info "  effective config saved to ${run_dir#$PROJECT_ROOT/}/effective_config.env"
     fi

--- a/common/module_schema/README.md
+++ b/common/module_schema/README.md
@@ -1,0 +1,96 @@
+# AirStack Module Manifest Schema
+
+The schema for `module.yaml` — the **thin module manifest** from
+[RFC #379 §2](https://github.com/castacks/AirStack/discussions/379): dependencies,
+identity, and test metadata only. **Wiring deliberately does not live here.** A
+module's interface is its launch file's declared args (with canonical-name defaults)
+plus the interface conventions spec; its wiring lives in whatever stack includes it.
+
+- Schema: [`module.schema.json`](module.schema.json)
+- Validator: [`tools/validate_module.py`](../../tools/validate_module.py)
+- Authoring workflow: [`.agents/skills/create-module`](../../.agents/skills/create-module/SKILL.md)
+
+## Validate a module
+
+```bash
+# Module directory (schema + cross-file checks):
+python3 tools/validate_module.py path/to/module_repo
+
+# Bare manifest (schema only):
+python3 tools/validate_module.py path/to/module.yaml
+```
+
+Human-readable errors go to stderr; a JSON verdict goes to stdout for scripts:
+
+```json
+{"valid": false, "errors": [{"path": "maintainer", "message": "required property is missing"}]}
+```
+
+Exit code 0 when valid, 1 otherwise. Contract tests:
+[`tests/meta/test_module_manifest_contract.py`](../../tests/meta/test_module_manifest_contract.py).
+
+## Fields
+
+### Required
+
+| Field | Shape | Notes |
+|---|---|---|
+| `name` | `^[a-z][a-z0-9_]*$` | module identity, snake_case |
+| `description` | string, ≥ 8 chars | one-liner for the registry catalog |
+| `maintainer` | email | required by governance (RFC #379 §8) |
+| `license` | non-empty string | checked at registration |
+| `type` | `isaac_extension` \| `ros_package` \| `data` \| `platform` | `platform` is future (RFC #380 §6) |
+| `airstack_compat` | semver range | vs trunk `.env` `VERSION`, e.g. `">=0.19.0 <0.21.0"`, `">=0.19.0-alpha.18 <0.20.0"`. Branch names (`main`) and partial versions (`0.19`) are invalid. |
+| `targets` | non-empty array of `robot` \| `gcs` \| `isaac-sim` \| `ms-airsim` | host containers touched |
+
+### Optional (with defaults)
+
+| Field | Default | Notes |
+|---|---|---|
+| `deps` | `{apt: [], pip: []}` | dependency tier 1 (RFC #379 §6); rosdep keys stay in `package.xml` |
+| `dockerfile` | `null` | tier 2: repo-relative path ending `Dockerfile.module`, written against `ARG BASE_IMAGE` |
+| `overlay_image` | `null` | tier 3: prebuilt overlay image reference |
+| `compose` | `null` | repo-relative compose fragment (mounts, env) |
+| `assets` | `[]` | `[{url, sha256, dest}]`: `url` must be `https://`, `sha256` is 64 lowercase hex chars, `dest` is a relative path (no `..`) |
+| `docs` | `{readme: README.md}` | or `{dir: <path>, nav: <path>}` |
+| `foxglove` | `null` | layout/panel fragment so operators can see the module |
+| `hooks` | — | `{host_setup: <script path>}` — see hook contract below |
+| `tests` | `{packages: [], marks: []}` | colcon unit-test packages + system-test marks from the known set (`unit`, `build_docker`, `build_packages`, `integration`, `liveliness`, `sensors`, `takeoff_hover_land`, `autonomy`, `waypoint_flight`, `optitrack`, `wiring`) |
+
+Unknown top-level keys are rejected (`additionalProperties: false`) — in particular
+slot/role/topic annotations, which the RFC deliberately excludes.
+
+### Hook contract (`hooks.host_setup`)
+
+A host-side setup script (precedent:
+`robot/ros_ws/src/perception/natnet_ros2/scripts/download-natnet-sdk.sh`). Every hook
+script MUST be:
+
+- **idempotent** — safe to run on every sync; exits fast when already done,
+- **sudo-free** — never escalates privileges,
+- **contained** — writes only inside the module checkout.
+
+## How validation works
+
+`tools/validate_module.py` is python3 stdlib + PyYAML (no `jsonschema` dependency).
+It loads `module.schema.json` and interprets it with a generic walker, so **schema
+evolution normally requires no validator changes**. The walker understands this
+draft-07 subset:
+
+`type` (incl. `["string", "null"]`), `required`, `properties`, `enum`, `pattern`,
+`items`, `additionalProperties`, `minLength`, `minItems`.
+
+Two custom behaviors are keyed off `x-airstack-*` annotations in the schema, never
+off field names in code:
+
+- `x-airstack-format`: `semver-range` (`airstack_compat`) and `safe-relative-path`
+  (no absolute paths, no `..` escapes) — the only custom "format" hooks.
+- Cross-file facts, applied only when validating a module **directory**:
+  - `x-airstack-check-exists`: the declared path (dockerfile / compose /
+    hooks.host_setup / docs entries) must exist in the module → **error**.
+  - `x-airstack-warn-missing-dir`: a `tests.packages` entry naming no directory in
+    the module → **warning** (stderr only; never affects validity or the verdict).
+
+A minimal valid module lives at
+[`tests/fixtures/modules/hello_module`](../../tests/fixtures/modules/hello_module) —
+both the contract-test fixture and a copyable example.

--- a/common/module_schema/module.schema.json
+++ b/common/module_schema/module.schema.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AirStack module manifest (module.yaml)",
+  "description": "The thin module manifest from RFC #379 §2: dependencies, identity, and test metadata only. Wiring (topics, remaps, slots) deliberately does NOT live here — a module's interface is its launch file's declared args plus the interface conventions spec. Consumed by tools/validate_module.py, which interprets the draft-07 subset: type, required, properties, enum, pattern, items, additionalProperties, minLength, minItems, plus the custom x-airstack-* annotations documented in common/module_schema/README.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "name",
+    "description",
+    "maintainer",
+    "license",
+    "type",
+    "airstack_compat",
+    "targets"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*$",
+      "description": "Module identity: lowercase snake_case, starts with a letter."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 8,
+      "description": "One-line human description shown in the registry catalog."
+    },
+    "maintainer": {
+      "type": "string",
+      "pattern": "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$",
+      "description": "Named maintainer email — required by governance (RFC #379 §8)."
+    },
+    "license": {
+      "type": "string",
+      "minLength": 1,
+      "description": "SPDX-style license string; checked at registration."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["isaac_extension", "ros_package", "data", "platform"],
+      "description": "What kind of module this is (platform is future — RFC #380 §6)."
+    },
+    "airstack_compat": {
+      "type": "string",
+      "x-airstack-format": "semver-range",
+      "description": "Semver range vs trunk .env VERSION, e.g. \">=0.19.0 <0.21.0\". Branch names and partial versions are invalid."
+    },
+    "targets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": ["robot", "gcs", "isaac-sim", "ms-airsim"]
+      },
+      "description": "Host containers this module touches."
+    },
+    "deps": {
+      "type": "object",
+      "additionalProperties": false,
+      "default": {"apt": [], "pip": []},
+      "description": "Dependency tier 1 (RFC #379 §6). rosdep keys live in package.xml, not here.",
+      "properties": {
+        "apt": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "pip": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "dockerfile": {
+      "type": ["string", "null"],
+      "default": null,
+      "pattern": "(^|/)Dockerfile\\.module$",
+      "x-airstack-format": "safe-relative-path",
+      "x-airstack-check-exists": true,
+      "description": "Dependency tier 2: repo-relative path to a Dockerfile.module written against ARG BASE_IMAGE, never a fixed base."
+    },
+    "overlay_image": {
+      "type": ["string", "null"],
+      "default": null,
+      "minLength": 1,
+      "description": "Dependency tier 3: prebuilt overlay image reference for monster deps."
+    },
+    "compose": {
+      "type": ["string", "null"],
+      "default": null,
+      "x-airstack-format": "safe-relative-path",
+      "x-airstack-check-exists": true,
+      "description": "Optional repo-relative docker compose fragment (mounts, env)."
+    },
+    "assets": {
+      "type": "array",
+      "default": [],
+      "description": "Large assets fetched to cache by `airstack sync` — no Git LFS in module repos (RFC #379 §10).",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["url", "sha256", "dest"],
+        "properties": {
+          "url": {
+            "type": "string",
+            "pattern": "^https://",
+            "description": "HTTPS download URL (http:// is rejected)."
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$",
+            "description": "Lowercase hex SHA-256 of the asset."
+          },
+          "dest": {
+            "type": "string",
+            "x-airstack-format": "safe-relative-path",
+            "description": "Destination path relative to the module checkout; never absolute, never escaping via '..'."
+          }
+        }
+      }
+    },
+    "docs": {
+      "type": "object",
+      "additionalProperties": false,
+      "default": {"readme": "README.md"},
+      "description": "Docs entry points embedded on the versioned site (RFC #379 §9): {readme: path} or {dir: path, nav: path}.",
+      "properties": {
+        "readme": {
+          "type": "string",
+          "x-airstack-format": "safe-relative-path",
+          "x-airstack-check-exists": true
+        },
+        "dir": {
+          "type": "string",
+          "x-airstack-format": "safe-relative-path",
+          "x-airstack-check-exists": true
+        },
+        "nav": {
+          "type": "string",
+          "x-airstack-format": "safe-relative-path",
+          "x-airstack-check-exists": true
+        }
+      }
+    },
+    "foxglove": {
+      "type": ["string", "null"],
+      "default": null,
+      "x-airstack-format": "safe-relative-path",
+      "description": "Optional Foxglove layout/panel fragment so operators can see the module in the field."
+    },
+    "hooks": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Lifecycle hooks. Contract for every hook script: idempotent, never uses sudo, writes only inside the module checkout.",
+      "properties": {
+        "host_setup": {
+          "type": "string",
+          "x-airstack-format": "safe-relative-path",
+          "x-airstack-check-exists": true,
+          "description": "Script run on the host after sync (precedent: natnet_ros2 scripts/download-natnet-sdk.sh). Must be idempotent, no sudo, and write only inside the module checkout."
+        }
+      }
+    },
+    "tests": {
+      "type": "object",
+      "additionalProperties": false,
+      "default": {"packages": [], "marks": []},
+      "description": "Test metadata: colcon unit-test packages (co-located test/) and the system-test marks the module's CI runs (RFC #379 §5).",
+      "properties": {
+        "packages": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "x-airstack-warn-missing-dir": true
+          }
+        },
+        "marks": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "unit",
+              "build_docker",
+              "build_packages",
+              "integration",
+              "liveliness",
+              "sensors",
+              "takeoff_hover_land",
+              "autonomy",
+              "waypoint_flight",
+              "optitrack",
+              "wiring"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/development/module_ci.md
+++ b/docs/development/module_ci.md
@@ -1,0 +1,185 @@
+# Module CI: the reusable system-test workflow
+
+AirStack module repos (`asm_*`) do not copy trunk's test suite — they call it.
+Trunk owns a reusable GitHub Actions workflow,
+[`module-system-tests.yml`](https://github.com/castacks/AirStack/blob/main/.github/workflows/module-system-tests.yml),
+that checks out `castacks/AirStack` at a pinned ref, checks out the calling
+module repo next to it, registers the module (`airstack module add` +
+`airstack module sync`), and runs the **existing system-test suite unchanged**
+on a GPU runner ([RFC #379 §5](https://github.com/castacks/AirStack/discussions/379)).
+A module's CI is therefore a ~12-line caller.
+
+## Wiring a module repo
+
+Create `.github/workflows/ci.yml` in the module repo:
+
+```yaml
+name: module-ci
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  system-tests:
+    uses: castacks/AirStack/.github/workflows/module-system-tests.yml@v0.19.0
+    with:
+      airstack_ref: v0.19.0    # pin and checkout ref move together
+      marks: "build_packages or liveliness"
+      sim: isaacsim
+    secrets: inherit           # castacks org secrets → registry image cache
+```
+
+Pin the workflow ref (`@v0.19.0`) and `airstack_ref` **together** — the
+workflow version and the trunk it tests should move as one. During
+pre-release development both may point at a branch; re-pin to a release tag
+as soon as one exists.
+
+`secrets: inherit` passes the castacks **org secrets**
+`DOCKER_REGISTRY_URL` / `DOCKER_REGISTRY_USERNAME` / `DOCKER_REGISTRY_PASSWORD`
+through to the workflow. The registry is the internal
+`airlab-docker.andrew.cmu.edu/airstack` (**not** ghcr); with the secrets
+present, image prep pulls versioned and floating cache tags instead of
+cold-building (see [Layer cache: the floating `cache_*` tag](intermediate/testing/ci_cd.md#layer-cache-the-floating-cache_-tag)).
+The secrets are optional — without them the run still works, just slower.
+
+## What the workflow does
+
+1. Refuses callers outside the `castacks` org (first-party policy, below).
+2. Checks out `castacks/AirStack@airstack_ref`, submodules included.
+3. Checks out the calling module repo (at the triggering SHA) into
+   `module-under-test/`, submodules included.
+4. Validates `module.yaml` with `tools/validate_module.py` — an invalid
+   manifest fails the run before any GPU time is spent.
+5. Registers the module: `airstack module add ./module-under-test` +
+   `airstack module sync`, then runs the module's declared
+   `hooks.host_setup` (hooks are idempotent by manifest contract, so the
+   explicit run is safe even when `module add` already ran it).
+6. Preps images (registry pull → floating-cache retag → build fallback),
+   creates the Isaac `omni_pass.env` when `sim` includes `isaacsim`.
+7. Runs `pytest tests/ -m "<marks>" --sim <sim> ...` exactly as trunk's
+   `system-tests.yml` does — same log-cli flags, same
+   `run_meta.json` honesty gate (a collect-only campaign is not a pass).
+   `build_packages` is auto-prepended to `marks` when absent, so code is
+   always built before launch tests run. If the module repo has a
+   `tests/` directory (configurable via `module_tests_dir`), it is appended
+   as an additional pytest path — module-specific system tests run in the
+   same session.
+8. Uploads `tests/results/` as artifact
+   `module-test-results-<module>-<run_id>` (90-day retention) and writes a
+   job summary (module, refs, marks, sim).
+
+## Inputs
+
+| Input | Default | Meaning |
+|---|---|---|
+| `airstack_ref` | *(required)* | Tag/branch/SHA of `castacks/AirStack` to test against. Must include the module CLI (`airstack module add`/`sync`). |
+| `marks` | `build_packages or liveliness` | pytest marks expression (see [tests/README.md](../../tests/README.md)). `build_packages` auto-prepended when absent. |
+| `sim` | `isaacsim` | Sim targets, comma-separated: `isaacsim,msairsim`. |
+| `num_robots` | `1` | Robot counts, comma-separated (e.g. `1,3`). |
+| `stress_iterations` | `1` | Iterations per (sim, num_robots) config. |
+| `stable_duration` | `120` | Seconds for the `test_stable` polling window. |
+| `module_tests_dir` | `tests` | Module-relative dir of extra pytest tests; appended to the pytest paths only if it exists. |
+| `runs_on` | `["self-hosted","airstack-ephemeral"]` | JSON array string parsed into `runs-on`. |
+| `timeout_minutes` | `120` | Job timeout. |
+
+| Secret | Required | Meaning |
+|---|---|---|
+| `DOCKER_REGISTRY_URL` | no | Internal registry host (castacks org secret). Enables registry-cache image prep. |
+| `DOCKER_REGISTRY_USERNAME` | no | Registry username (org secret). |
+| `DOCKER_REGISTRY_PASSWORD` | no | Registry password (org secret). |
+
+Runs are **read-only against the registry cache**: modules can consume the
+floating cache tags but never republish them (`AIRSTACK_REGISTRY_CACHE_PUSH`
+stays unset; only trunk's `docker-build.yml` writes).
+
+## First-party policy
+
+The workflow hard-fails when the calling repository is not in the `castacks`
+org. Org GPU runners (OSMO pool, sim licenses) and org registry secrets never
+serve third-party code. External modules will be served by a
+**dispatch-triggered test bench** (RFC #379 §5, Phase 4): trunk receives a
+`repository_dispatch {module_repo, module_ref, airstack_ref}`, runs on its own
+runners, and posts a check-run back via a GitHub App — secrets and licenses
+never leave trunk, bench time is gated and rate-limited. Until that lands,
+external authors can run the suite on their own runners by overriding
+`runs_on` in a fork of the workflow, but they get no castacks compute.
+
+## Which marks should a module run?
+
+System tests double as conformance tests — e.g. `tests/waypoint_checker.py`
+judges the odometry track regardless of which planner produced it, so passing
+`waypoint_flight` *is* the behavioral definition of a working global planner.
+Guidance by module category (RFC #379 §5):
+
+| Module category | Marks |
+|---|---|
+| Global planner | `waypoint_flight`, `autonomy` |
+| State estimator | `liveliness`, `sensors`, `takeoff_hover_land` |
+| World model / perception | `liveliness`, `sensors` |
+| Sim extension | `liveliness` (on the affected sim) |
+
+Declare the chosen marks in the manifest (`tests.marks` in `module.yaml`) so
+the claim is inspectable; the CI caller is where they actually run.
+
+## Cost ladder
+
+- **Every push:** `unit` + `build_packages` — the module's own business, run
+  however the module likes (a plain `ubuntu-latest` job with the published
+  image, or `marks: build_packages` through this workflow — pure
+  `build_packages` runs never bake sim images). Minutes, no GPU.
+- **PR / nightly:** `liveliness` (plus `sensors` where relevant) via this
+  workflow; `sim: msairsim` is the cheap bring-up.
+- **Release / compatibility claim:** the module's full conformance mark set on
+  GPU — this run is what stamps the badge.
+- **Trunk-side nightly canary** (Phase 4) runs registered modules against
+  `develop` so breakage surfaces the day it lands.
+
+**Badge semantics:** a compat badge reads "module M @ vM passes marks {…} in a
+test stack derived from reference stack S, on AirStack vX" — conformance to a
+*stack*, demonstrated by flying it.
+
+## Weekly canary (recommended)
+
+Until the trunk-side canary exists, give the module repo its own cron so drift
+against trunk `develop` surfaces weekly instead of at the next release:
+
+```yaml
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
+
+jobs:
+  canary:
+    uses: castacks/AirStack/.github/workflows/module-system-tests.yml@develop
+    with:
+      airstack_ref: develop
+      marks: "build_packages or liveliness"
+      sim: isaacsim
+    secrets: inherit
+```
+
+A red canary is a compatibility signal, not necessarily a module bug — check
+trunk's changelog before touching module code.
+
+## Smoke-testing the workflow itself
+
+Trunk maintainers can run the workflow against any module repo without a
+caller, via `workflow_dispatch` (extra inputs `module_repo` + `module_ref`
+select the module):
+
+```bash
+gh workflow run module-system-tests.yml --repo castacks/AirStack \
+  --ref develop \
+  -f module_repo=castacks/asm_dfm2_disturbances -f module_ref=main \
+  -f airstack_ref=develop \
+  -f marks="build_packages or liveliness" -f sim=isaacsim
+```
+
+## GPU runners for module repos
+
+With the default `runs_on`, jobs queue for the label pair
+`[self-hosted, airstack-ephemeral]` — the ephemeral OSMO-backed runners. The
+orchestrator polls **one repo per instance**, so a module repo must be added
+to the poll list before its jobs are picked up: see
+[CI/CD Orchestrator → Module repos](../../tests/ci-cd-orchestrator.md#module-repos).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
               - End-to-End Testing: docs/development/intermediate/testing/end_to_end_testing.md
               - CI/CD Pipeline: docs/development/intermediate/testing/ci_cd.md
               - CI/CD Orchestrator: tests/ci-cd-orchestrator.md
+              - Module CI: docs/development/module_ci.md
           - Frame Conventions: docs/development/intermediate/frame_conventions.md
           - Docker Build Profiles: docs/development/intermediate/docker-build-profiles.md
           - Contributing:

--- a/tests/fixtures/modules/hello_module/hello_module/hello_module/__init__.py
+++ b/tests/fixtures/modules/hello_module/hello_module/hello_module/__init__.py
@@ -1,0 +1,3 @@
+"""hello_module — minimal fixture package for module manifest contract tests."""
+
+__version__ = "0.1.0"

--- a/tests/fixtures/modules/hello_module/hello_module/hello_module/hello_node.py
+++ b/tests/fixtures/modules/hello_module/hello_module/hello_module/hello_node.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Tiny rclpy node: logs one greeting, then exits."""
+
+import rclpy
+from rclpy.node import Node
+
+
+class HelloNode(Node):
+    def __init__(self):
+        super().__init__("hello_node")
+        self.get_logger().info("hello_module says hello")
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = HelloNode()
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/modules/hello_module/hello_module/package.xml
+++ b/tests/fixtures/modules/hello_module/hello_module/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>hello_module</name>
+  <version>0.1.0</version>
+  <description>Minimal hello-world fixture package for module manifest contract tests.</description>
+  <maintainer email="test@example.com">AirStack Test Fixture</maintainer>
+  <license>MIT</license>
+
+  <exec_depend>rclpy</exec_depend>
+
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/tests/fixtures/modules/hello_module/hello_module/setup.cfg
+++ b/tests/fixtures/modules/hello_module/hello_module/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/hello_module
+[install]
+install_scripts=$base/lib/hello_module

--- a/tests/fixtures/modules/hello_module/hello_module/setup.py
+++ b/tests/fixtures/modules/hello_module/hello_module/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+package_name = "hello_module"
+
+setup(
+    name=package_name,
+    version="0.1.0",
+    packages=[package_name],
+    data_files=[
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="AirStack Test Fixture",
+    maintainer_email="test@example.com",
+    description="Minimal hello-world fixture package for module manifest contract tests.",
+    license="MIT",
+    extras_require={"test": ["pytest"]},
+    entry_points={
+        "console_scripts": [
+            "hello_node = hello_module.hello_node:main",
+        ],
+    },
+)

--- a/tests/fixtures/modules/hello_module/hello_module/test/test_import.py
+++ b/tests/fixtures/modules/hello_module/hello_module/test/test_import.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 Carnegie Mellon University
+# MIT License - see LICENSE in the repository root for full text.
+"""Import smoke tests for the hello_module fixture package.
+
+This fixture lives under ``tests/``, so broad pytest recursion collects it directly
+(unlike real co-located colcon unit tests, which are injected via
+``colcon_unit_test_packages.yaml``). It is marked ``unit`` by hand and made
+self-sufficient: the package import root goes on ``sys.path`` here.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_PKG_ROOT = Path(__file__).resolve().parents[1]
+if str(_PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PKG_ROOT))
+
+
+def test_package_imports():
+    import hello_module
+
+    assert hello_module.__version__
+
+
+def test_node_module_imports_when_rclpy_available():
+    pytest.importorskip("rclpy")
+    from hello_module import hello_node
+
+    assert callable(hello_node.main)

--- a/tests/fixtures/modules/hello_module/module.yaml
+++ b/tests/fixtures/modules/hello_module/module.yaml
@@ -1,0 +1,13 @@
+# Minimal valid module manifest — fixture for tests/meta/test_module_manifest_contract.py.
+# Schema: common/module_schema/module.schema.json (RFC #379 §2).
+name: hello_module
+description: Minimal hello-world module fixture for manifest-contract tests.
+maintainer: test@example.com
+license: MIT
+type: ros_package
+airstack_compat: ">=0.19.0 <0.21.0"
+targets: [robot]
+
+tests:
+  packages: [hello_module]
+  marks: []

--- a/tests/goldens/wiring/README.md
+++ b/tests/goldens/wiring/README.md
@@ -1,0 +1,58 @@
+# Wiring snapshot goldens
+
+Committed observed-wiring baselines for the drift check in
+[`tests/system/test_wiring_snapshot.py`](../../system/test_wiring_snapshot.py)
+(RFC #379 §4.4: the wiring picture is snapshotted from the **running** ROS
+graph — observed, never generated from configuration — so it cannot lie or
+rot).
+
+## Files
+
+One golden per `(sim, num_robots)` configuration, named
+
+```text
+full_default.<sim>.<num_robots>robot.md
+```
+
+e.g. `full_default.isaacsim.1robot.md`, `full_default.msairsim.3robot.md`.
+Each file is a full `wiring.md`: provenance lines, a mermaid dataflow diagram
+(nodes grouped by namespace, edges labeled topic/type), and a
+machine-readable JSON trailer (`<!-- wiring-graph-v1 ... -->`) that the drift
+check actually compares. **Never hand-edit these files** — they are only ever
+copied from a validated run.
+
+## Bootstrap: committing the first golden
+
+Goldens are committed from a validated local run:
+
+1. Run the wiring mark against the target configuration, e.g.
+
+   ```bash
+   airstack test -m wiring --sim isaacsim --num-robots 1 -v
+   ```
+
+2. With no golden present, the test **passes** and writes the observed
+   snapshot to `tests/results/<timestamp>/wiring/observed_full_default.md`,
+   logging an `INSTRUCTION:` line with the exact destination path.
+
+3. Validate the observed snapshot (skim the mermaid diagram: expected nodes
+   present, no junk endpoints), then copy it to the golden name and commit:
+
+   ```bash
+   cp tests/results/<timestamp>/wiring/observed_full_default.md \
+      tests/goldens/wiring/full_default.isaacsim.1robot.md
+   ```
+
+## Drift check semantics
+
+Once a golden exists, the test snapshots the running graph and diffs the two
+normalized graphs (`tests/wiring_snapshot.py diff`): missing/extra nodes,
+missing/extra pub/sub edges, per-edge QoS mismatches, and per-topic type
+mismatches all fail the test with a JSON verdict. Infra noise
+(`/parameter_events`, `/rosout`, pid-suffixed `launch_ros_*` /
+`transform_listener_impl_*` / `_ros2cli*` nodes) is normalized out on both
+sides; `/tf` and `/tf_static` are kept — frame plumbing is wiring.
+
+A PR that intentionally changes wiring must regenerate the affected goldens
+(same flow as bootstrap) and commit them, so the review diff shows the
+topology change.

--- a/tests/goldens/wiring/full_default.isaacsim.1robot.md
+++ b/tests/goldens/wiring/full_default.isaacsim.1robot.md
@@ -1,0 +1,7633 @@
+# Wiring snapshot: full_default
+
+- **generated-by**: tests/system/test_wiring_snapshot.py
+- **date**: 2026-08-20 20:59:49
+- **sim**: isaacsim
+- **num_robots**: 1
+- **source-sha**: 5c6c4a4191bd
+
+```mermaid
+graph LR
+  subgraph g0["behavior"]
+    n2["/robot_1/behavior/drone_safety_monitor/drone_safety_monitor"]
+  end
+  subgraph g1["control"]
+    n3["/robot_1/control/pid_controller"]
+  end
+  subgraph g2["droan"]
+    n4["/robot_1/droan/disparity_expander_node"]
+  end
+  subgraph g3["interface"]
+    n6["/robot_1/interface/mavros/actuator_control"]
+    n7["/robot_1/interface/mavros/adsb"]
+    n8["/robot_1/interface/mavros/altitude"]
+    n9["/robot_1/interface/mavros/cam_imu_sync"]
+    n10["/robot_1/interface/mavros/camera"]
+    n11["/robot_1/interface/mavros/cellular_status"]
+    n12["/robot_1/interface/mavros/cmd"]
+    n13["/robot_1/interface/mavros/companion_process"]
+    n14["/robot_1/interface/mavros/debug_value"]
+    n15["/robot_1/interface/mavros/esc_status"]
+    n16["/robot_1/interface/mavros/esc_telemetry"]
+    n17["/robot_1/interface/mavros/fake_gps"]
+    n18["/robot_1/interface/mavros/ftp"]
+    n19["/robot_1/interface/mavros/geofence"]
+    n20["/robot_1/interface/mavros/gimbal_control"]
+    n21["/robot_1/interface/mavros/global_position"]
+    n22["/robot_1/interface/mavros/gps_input"]
+    n23["/robot_1/interface/mavros/gps_rtk"]
+    n24["/robot_1/interface/mavros/gpsstatus"]
+    n25["/robot_1/interface/mavros/guided_target"]
+    n26["/robot_1/interface/mavros/hil"]
+    n27["/robot_1/interface/mavros/home_position"]
+    n28["/robot_1/interface/mavros/imu"]
+    n29["/robot_1/interface/mavros/landing_target"]
+    n30["/robot_1/interface/mavros/local_position"]
+    n31["/robot_1/interface/mavros/log_transfer"]
+    n32["/robot_1/interface/mavros/mag_calibration"]
+    n33["/robot_1/interface/mavros/manual_control"]
+    n34["/robot_1/interface/mavros/mavros"]
+    n35["/robot_1/interface/mavros/mavros_node"]
+    n36["/robot_1/interface/mavros/mavros_router"]
+    n37["/robot_1/interface/mavros/mission"]
+    n38["/robot_1/interface/mavros/mocap"]
+    n39["/robot_1/interface/mavros/mount_control"]
+    n40["/robot_1/interface/mavros/nav_controller_output"]
+    n41["/robot_1/interface/mavros/obstacle"]
+    n42["/robot_1/interface/mavros/obstacle_distance_3d"]
+    n43["/robot_1/interface/mavros/odometry"]
+    n44["/robot_1/interface/mavros/onboard_computer"]
+    n45["/robot_1/interface/mavros/open_drone_id"]
+    n46["/robot_1/interface/mavros/optical_flow"]
+    n47["/robot_1/interface/mavros/param"]
+    n48["/robot_1/interface/mavros/play_tune"]
+    n49["/robot_1/interface/mavros/px4flow"]
+    n50["/robot_1/interface/mavros/rallypoint"]
+    n51["/robot_1/interface/mavros/rc"]
+    n52["/robot_1/interface/mavros/setpoint_accel"]
+    n53["/robot_1/interface/mavros/setpoint_attitude"]
+    n54["/robot_1/interface/mavros/setpoint_position"]
+    n55["/robot_1/interface/mavros/setpoint_raw"]
+    n56["/robot_1/interface/mavros/setpoint_trajectory"]
+    n57["/robot_1/interface/mavros/setpoint_velocity"]
+    n58["/robot_1/interface/mavros/sim_state"]
+    n59["/robot_1/interface/mavros/sys"]
+    n60["/robot_1/interface/mavros/tdr_radio"]
+    n61["/robot_1/interface/mavros/terrain"]
+    n62["/robot_1/interface/mavros/time"]
+    n63["/robot_1/interface/mavros/trajectory"]
+    n64["/robot_1/interface/mavros/tunnel"]
+    n65["/robot_1/interface/mavros/vfr_hud"]
+    n66["/robot_1/interface/mavros/vision_pose"]
+    n67["/robot_1/interface/mavros/vision_speed"]
+    n68["/robot_1/interface/mavros/wind"]
+    n69["/robot_1/interface/odom_modifier"]
+    n70["/robot_1/interface/robot_interface"]
+  end
+  subgraph g4["odometry_conversion"]
+    n71["/robot_1/odometry_conversion/odometry_conversion"]
+  end
+  subgraph g5["perception"]
+    n72["/robot_1/perception/stereo_image_proc/disparity_node"]
+    n73["/robot_1/perception/stereo_pointcloud"]
+  end
+  subgraph g6["robot_1"]
+    n1["/robot_1/Container"]
+    n5["/robot_1/gossip_node"]
+    n74["/robot_1/random_walk_node"]
+    n75["/robot_1/robot_state_publisher"]
+    n78["/robot_1/topic_keepalive"]
+    n81["/robot_1/vdb_mapping"]
+    n82["/robot_1/world_to_map_broadcaster"]
+  end
+  subgraph g7["root"]
+    n0["/action_relay_client"]
+  end
+  subgraph g8["sensors"]
+    n76["/robot_1/sensors/lidar_point_cloud_filter"]
+  end
+  subgraph g9["takeoff_landing_planner"]
+    n77["/robot_1/takeoff_landing_planner/takeoff_landing_task"]
+  end
+  subgraph g10["trajectory_controller"]
+    n79["/robot_1/trajectory_controller/fixed_trajectory_task"]
+    n80["/robot_1/trajectory_controller/trajectory_control_node"]
+  end
+  d0(["/clock (no publishers)"]) -->|"/clock<br/>Clock"| n1
+  d0 -->|"/clock<br/>Clock"| n2
+  d0 -->|"/clock<br/>Clock"| n3
+  d0 -->|"/clock<br/>Clock"| n4
+  d0 -->|"/clock<br/>Clock"| n5
+  d0 -->|"/clock<br/>Clock"| n6
+  d0 -->|"/clock<br/>Clock"| n7
+  d0 -->|"/clock<br/>Clock"| n8
+  d0 -->|"/clock<br/>Clock"| n9
+  d0 -->|"/clock<br/>Clock"| n10
+  d0 -->|"/clock<br/>Clock"| n11
+  d0 -->|"/clock<br/>Clock"| n12
+  d0 -->|"/clock<br/>Clock"| n13
+  d0 -->|"/clock<br/>Clock"| n14
+  d0 -->|"/clock<br/>Clock"| n15
+  d0 -->|"/clock<br/>Clock"| n16
+  d0 -->|"/clock<br/>Clock"| n17
+  d0 -->|"/clock<br/>Clock"| n18
+  d0 -->|"/clock<br/>Clock"| n19
+  d0 -->|"/clock<br/>Clock"| n20
+  d0 -->|"/clock<br/>Clock"| n21
+  d0 -->|"/clock<br/>Clock"| n22
+  d0 -->|"/clock<br/>Clock"| n23
+  d0 -->|"/clock<br/>Clock"| n24
+  d0 -->|"/clock<br/>Clock"| n25
+  d0 -->|"/clock<br/>Clock"| n26
+  d0 -->|"/clock<br/>Clock"| n27
+  d0 -->|"/clock<br/>Clock"| n28
+  d0 -->|"/clock<br/>Clock"| n29
+  d0 -->|"/clock<br/>Clock"| n30
+  d0 -->|"/clock<br/>Clock"| n31
+  d0 -->|"/clock<br/>Clock"| n32
+  d0 -->|"/clock<br/>Clock"| n33
+  d0 -->|"/clock<br/>Clock"| n34
+  d0 -->|"/clock<br/>Clock"| n35
+  d0 -->|"/clock<br/>Clock"| n36
+  d0 -->|"/clock<br/>Clock"| n37
+  d0 -->|"/clock<br/>Clock"| n38
+  d0 -->|"/clock<br/>Clock"| n39
+  d0 -->|"/clock<br/>Clock"| n40
+  d0 -->|"/clock<br/>Clock"| n41
+  d0 -->|"/clock<br/>Clock"| n42
+  d0 -->|"/clock<br/>Clock"| n43
+  d0 -->|"/clock<br/>Clock"| n44
+  d0 -->|"/clock<br/>Clock"| n45
+  d0 -->|"/clock<br/>Clock"| n46
+  d0 -->|"/clock<br/>Clock"| n47
+  d0 -->|"/clock<br/>Clock"| n48
+  d0 -->|"/clock<br/>Clock"| n49
+  d0 -->|"/clock<br/>Clock"| n50
+  d0 -->|"/clock<br/>Clock"| n51
+  d0 -->|"/clock<br/>Clock"| n52
+  d0 -->|"/clock<br/>Clock"| n53
+  d0 -->|"/clock<br/>Clock"| n54
+  d0 -->|"/clock<br/>Clock"| n55
+  d0 -->|"/clock<br/>Clock"| n56
+  d0 -->|"/clock<br/>Clock"| n57
+  d0 -->|"/clock<br/>Clock"| n58
+  d0 -->|"/clock<br/>Clock"| n59
+  d0 -->|"/clock<br/>Clock"| n60
+  d0 -->|"/clock<br/>Clock"| n61
+  d0 -->|"/clock<br/>Clock"| n62
+  d0 -->|"/clock<br/>Clock"| n63
+  d0 -->|"/clock<br/>Clock"| n64
+  d0 -->|"/clock<br/>Clock"| n65
+  d0 -->|"/clock<br/>Clock"| n66
+  d0 -->|"/clock<br/>Clock"| n67
+  d0 -->|"/clock<br/>Clock"| n68
+  d0 -->|"/clock<br/>Clock"| n69
+  d0 -->|"/clock<br/>Clock"| n70
+  d0 -->|"/clock<br/>Clock"| n71
+  d0 -->|"/clock<br/>Clock"| n72
+  d0 -->|"/clock<br/>Clock"| n73
+  d0 -->|"/clock<br/>Clock"| n74
+  d0 -->|"/clock<br/>Clock"| n75
+  d0 -->|"/clock<br/>Clock"| n76
+  d0 -->|"/clock<br/>Clock"| n77
+  d0 -->|"/clock<br/>Clock"| n78
+  d0 -->|"/clock<br/>Clock"| n79
+  d0 -->|"/clock<br/>Clock"| n80
+  d0 -->|"/clock<br/>Clock"| n81
+  d0 -->|"/clock<br/>Clock"| n82
+  n34 -->|"/diagnostics<br/>DiagnosticArray"| d1(["/diagnostics (no subscribers)"])
+  n36 -->|"/diagnostics<br/>DiagnosticArray"| d1
+  n5 -->|"/gossip/peers<br/>PeerProfile"| n5
+  n25 -->|"/move_base_simple/goal<br/>PoseStamped"| d2(["/move_base_simple/goal (no subscribers)"])
+  d3(["/robot_1/behavior/drone_safety_monitor/command (no publishers)"]) -->|"/robot_1/behavior/drone_safety_monitor/command<br/>String"| n2
+  n2 -->|"/robot_1/behavior/drone_safety_monitor/state_estimate_timed_out<br/>Bool"| n77
+  n70 -->|"/robot_1/control/reset_integrators<br/>Empty"| n3
+  n3 -->|"/robot_1/control/vx_pid_info<br/>PIDInfo"| d4(["/robot_1/control/vx_pid_info (no subscribers)"])
+  n3 -->|"/robot_1/control/vy_pid_info<br/>PIDInfo"| d5(["/robot_1/control/vy_pid_info (no subscribers)"])
+  n3 -->|"/robot_1/control/vz_pid_info<br/>PIDInfo"| d6(["/robot_1/control/vz_pid_info (no subscribers)"])
+  n3 -->|"/robot_1/control/x_pid_info<br/>PIDInfo"| d7(["/robot_1/control/x_pid_info (no subscribers)"])
+  n3 -->|"/robot_1/control/y_pid_info<br/>PIDInfo"| d8(["/robot_1/control/y_pid_info (no subscribers)"])
+  n3 -->|"/robot_1/control/z_pid_info<br/>PIDInfo"| d9(["/robot_1/control/z_pid_info (no subscribers)"])
+  n5 -->|"/robot_1/coordination/peer_registry<br/>PeerProfile"| d10(["/robot_1/coordination/peer_registry (no subscribers)"])
+  n69 -->|"/robot_1/cross_track_error<br/>PoseStamped"| d11(["/robot_1/cross_track_error (no subscribers)"])
+  n4 -->|"/robot_1/droan/background_expanded<br/>Image"| d12(["/robot_1/droan/background_expanded (no subscribers)"])
+  d13(["/robot_1/droan/clear_map (no publishers)"]) -->|"/robot_1/droan/clear_map<br/>Empty"| n4
+  d14(["/robot_1/droan/disparity_graph (no publishers)"]) -->|"/robot_1/droan/disparity_graph<br/>MarkerArray"| n78
+  d15(["/robot_1/droan/disparity_map_debug (no publishers)"]) -->|"/robot_1/droan/disparity_map_debug<br/>MarkerArray"| n78
+  d16(["/robot_1/droan/expansion_cloud (no publishers)"]) -->|"/robot_1/droan/expansion_cloud<br/>PointCloud2"| n78
+  d17(["/robot_1/droan/expansion_poly (no publishers)"]) -->|"/robot_1/droan/expansion_poly<br/>MarkerArray"| n78
+  n4 -->|"/robot_1/droan/fg_bg_cloud<br/>PointCloud2"| n78
+  n4 -->|"/robot_1/droan/foreground_expanded<br/>Image"| d18(["/robot_1/droan/foreground_expanded (no subscribers)"])
+  d19(["/robot_1/droan/frustum (no publishers)"]) -->|"/robot_1/droan/frustum<br/>Marker"| n78
+  n4 -->|"/robot_1/droan/graph_vis<br/>MarkerArray"| n78
+  n4 -->|"/robot_1/droan/local_planner_global_plan_vis<br/>MarkerArray"| n78
+  d20(["/robot_1/droan/reset_stuck (no publishers)"]) -->|"/robot_1/droan/reset_stuck<br/>Empty"| n4
+  n4 -->|"/robot_1/droan/rewind_info<br/>MarkerArray"| n78
+  n4 -->|"/robot_1/droan/stuck<br/>Bool"| d21(["/robot_1/droan/stuck (no subscribers)"])
+  n4 -->|"/robot_1/droan/traj_debug<br/>MarkerArray"| n78
+  d22(["/robot_1/droan/trajectory_library_vis (no publishers)"]) -->|"/robot_1/droan/trajectory_library_vis<br/>MarkerArray"| n78
+  d23(["/robot_1/droan/virtual_obstacles (no publishers)"]) -->|"/robot_1/droan/virtual_obstacles<br/>MarkerArray"| n78
+  n69 -->|"/robot_1/global_plan<br/>Path"| n4
+  n69 -->|"/robot_1/global_plan<br/>Path"| n5
+  n69 -->|"/robot_1/global_plan<br/>Path"| n78
+  n74 -->|"/robot_1/global_plan<br/>Path"| n4
+  n74 -->|"/robot_1/global_plan<br/>Path"| n5
+  n74 -->|"/robot_1/global_plan<br/>Path"| n78
+  d24(["/robot_1/interface/attitude_thrust_command (no publishers)"]) -->|"/robot_1/interface/attitude_thrust_command<br/>AttitudeThrust"| n70
+  d25(["/robot_1/interface/cmd_attitude_thrust (no publishers)"]) -->|"/robot_1/interface/cmd_attitude_thrust<br/>AttitudeThrust"| n70
+  n69 -->|"/robot_1/interface/cmd_pose<br/>PoseStamped"| n70
+  d26(["/robot_1/interface/cmd_rate_thrust (no publishers)"]) -->|"/robot_1/interface/cmd_rate_thrust<br/>RateThrust"| n70
+  n3 -->|"/robot_1/interface/cmd_roll_pitch_yawrate_thrust<br/>RollPitchYawrateThrust"| n70
+  d27(["/robot_1/interface/cmd_torque_thrust (no publishers)"]) -->|"/robot_1/interface/cmd_torque_thrust<br/>TorqueThrust"| n70
+  n69 -->|"/robot_1/interface/cmd_velocity<br/>TwistStamped"| n70
+  n70 -->|"/robot_1/interface/has_control<br/>Bool"| n77
+  n70 -->|"/robot_1/interface/is_armed<br/>Bool"| n77
+  d28(["/robot_1/interface/mavros/actuator_control (no publishers)"]) -->|"/robot_1/interface/mavros/actuator_control<br/>ActuatorControl"| n6
+  d29(["/robot_1/interface/mavros/adsb/send (no publishers)"]) -->|"/robot_1/interface/mavros/adsb/send<br/>ADSBVehicle"| n7
+  n7 -->|"/robot_1/interface/mavros/adsb/vehicle<br/>ADSBVehicle"| d30(["/robot_1/interface/mavros/adsb/vehicle (no subscribers)"])
+  n8 -->|"/robot_1/interface/mavros/altitude<br/>Altitude"| d31(["/robot_1/interface/mavros/altitude (no subscribers)"])
+  n59 -->|"/robot_1/interface/mavros/battery<br/>BatteryState"| d32(["/robot_1/interface/mavros/battery (no subscribers)"])
+  n9 -->|"/robot_1/interface/mavros/cam_imu_sync/cam_imu_stamp<br/>CamIMUStamp"| d33(["/robot_1/interface/mavros/cam_imu_sync/cam_imu_stamp (no subscribers)"])
+  n10 -->|"/robot_1/interface/mavros/camera/image_captured<br/>CameraImageCaptured"| d34(["/robot_1/interface/mavros/camera/image_captured (no subscribers)"])
+  d35(["/robot_1/interface/mavros/cellular_status/status (no publishers)"]) -->|"/robot_1/interface/mavros/cellular_status/status<br/>CellularStatus"| n11
+  d36(["/robot_1/interface/mavros/companion_process/status (no publishers)"]) -->|"/robot_1/interface/mavros/companion_process/status<br/>CompanionProcessStatus"| n13
+  n14 -->|"/robot_1/interface/mavros/debug_value/debug<br/>DebugValue"| d37(["/robot_1/interface/mavros/debug_value/debug (no subscribers)"])
+  n14 -->|"/robot_1/interface/mavros/debug_value/debug_float_array<br/>DebugValue"| d38(["/robot_1/interface/mavros/debug_value/debug_float_array (no subscribers)"])
+  n14 -->|"/robot_1/interface/mavros/debug_value/debug_vector<br/>DebugValue"| d39(["/robot_1/interface/mavros/debug_value/debug_vector (no subscribers)"])
+  n14 -->|"/robot_1/interface/mavros/debug_value/named_value_float<br/>DebugValue"| d40(["/robot_1/interface/mavros/debug_value/named_value_float (no subscribers)"])
+  n14 -->|"/robot_1/interface/mavros/debug_value/named_value_int<br/>DebugValue"| d41(["/robot_1/interface/mavros/debug_value/named_value_int (no subscribers)"])
+  d42(["/robot_1/interface/mavros/debug_value/send (no publishers)"]) -->|"/robot_1/interface/mavros/debug_value/send<br/>DebugValue"| n14
+  n15 -->|"/robot_1/interface/mavros/esc_status/info<br/>ESCInfo"| d43(["/robot_1/interface/mavros/esc_status/info (no subscribers)"])
+  n15 -->|"/robot_1/interface/mavros/esc_status/status<br/>ESCStatus"| d44(["/robot_1/interface/mavros/esc_status/status (no subscribers)"])
+  n16 -->|"/robot_1/interface/mavros/esc_telemetry/telemetry<br/>ESCTelemetry"| d45(["/robot_1/interface/mavros/esc_telemetry/telemetry (no subscribers)"])
+  n59 -->|"/robot_1/interface/mavros/estimator_status<br/>EstimatorStatus"| d46(["/robot_1/interface/mavros/estimator_status (no subscribers)"])
+  n59 -->|"/robot_1/interface/mavros/extended_state<br/>ExtendedState"| n77
+  d47(["/robot_1/interface/mavros/fake_gps/mocap/tf (no publishers)"]) -->|"/robot_1/interface/mavros/fake_gps/mocap/tf<br/>TransformStamped"| n17
+  n19 -->|"/robot_1/interface/mavros/geofence/fences<br/>WaypointList"| d48(["/robot_1/interface/mavros/geofence/fences (no subscribers)"])
+  n20 -->|"/robot_1/interface/mavros/gimbal_control/device/attitude_status<br/>GimbalDeviceAttitudeStatus"| d49(["/robot_1/interface/mavros/gimbal_control/device/attitude_status (no subscribers)"])
+  n20 -->|"/robot_1/interface/mavros/gimbal_control/device/info<br/>GimbalDeviceInformation"| d50(["/robot_1/interface/mavros/gimbal_control/device/info (no subscribers)"])
+  d51(["/robot_1/interface/mavros/gimbal_control/device/set_attitude (no publishers)"]) -->|"/robot_1/interface/mavros/gimbal_control/device/set_attitude<br/>GimbalDeviceSetAttitude"| n20
+  n20 -->|"/robot_1/interface/mavros/gimbal_control/manager/info<br/>GimbalManagerInformation"| d52(["/robot_1/interface/mavros/gimbal_control/manager/info (no subscribers)"])
+  d53(["/robot_1/interface/mavros/gimbal_control/manager/set_attitude (no publishers)"]) -->|"/robot_1/interface/mavros/gimbal_control/manager/set_attitude<br/>GimbalManagerSetAttitude"| n20
+  d54(["/robot_1/interface/mavros/gimbal_control/manager/set_manual_control (no publishers)"]) -->|"/robot_1/interface/mavros/gimbal_control/manager/set_manual_control<br/>GimbalManagerSetPitchyaw"| n20
+  d55(["/robot_1/interface/mavros/gimbal_control/manager/set_pitchyaw (no publishers)"]) -->|"/robot_1/interface/mavros/gimbal_control/manager/set_pitchyaw<br/>GimbalManagerSetPitchyaw"| n20
+  n20 -->|"/robot_1/interface/mavros/gimbal_control/manager/status<br/>GimbalManagerStatus"| d56(["/robot_1/interface/mavros/gimbal_control/manager/status (no subscribers)"])
+  n21 -->|"/robot_1/interface/mavros/global_position/compass_hdg<br/>Float64"| n5
+  n21 -->|"/robot_1/interface/mavros/global_position/global<br/>NavSatFix"| n54
+  n21 -->|"/robot_1/interface/mavros/global_position/global<br/>NavSatFix"| n70
+  n21 -->|"/robot_1/interface/mavros/global_position/gp_lp_offset<br/>PoseStamped"| d57(["/robot_1/interface/mavros/global_position/gp_lp_offset (no subscribers)"])
+  n21 -->|"/robot_1/interface/mavros/global_position/gp_origin<br/>GeoPointStamped"| n25
+  n21 -->|"/robot_1/interface/mavros/global_position/local<br/>Odometry"| n70
+  n21 -->|"/robot_1/interface/mavros/global_position/raw/fix<br/>NavSatFix"| n5
+  n21 -->|"/robot_1/interface/mavros/global_position/raw/gps_vel<br/>TwistStamped"| d58(["/robot_1/interface/mavros/global_position/raw/gps_vel (no subscribers)"])
+  n21 -->|"/robot_1/interface/mavros/global_position/raw/satellites<br/>UInt32"| d59(["/robot_1/interface/mavros/global_position/raw/satellites (no subscribers)"])
+  n21 -->|"/robot_1/interface/mavros/global_position/rel_alt<br/>Float64"| d60(["/robot_1/interface/mavros/global_position/rel_alt (no subscribers)"])
+  d61(["/robot_1/interface/mavros/global_position/set_gp_origin (no publishers)"]) -->|"/robot_1/interface/mavros/global_position/set_gp_origin<br/>GeoPointStamped"| n21
+  d62(["/robot_1/interface/mavros/gps_input/gps_input (no publishers)"]) -->|"/robot_1/interface/mavros/gps_input/gps_input<br/>GPSINPUT"| n22
+  n23 -->|"/robot_1/interface/mavros/gps_rtk/rtk_baseline<br/>RTKBaseline"| d63(["/robot_1/interface/mavros/gps_rtk/rtk_baseline (no subscribers)"])
+  d64(["/robot_1/interface/mavros/gps_rtk/send_rtcm (no publishers)"]) -->|"/robot_1/interface/mavros/gps_rtk/send_rtcm<br/>RTCM"| n23
+  n24 -->|"/robot_1/interface/mavros/gpsstatus/gps1/raw<br/>GPSRAW"| d65(["/robot_1/interface/mavros/gpsstatus/gps1/raw (no subscribers)"])
+  n24 -->|"/robot_1/interface/mavros/gpsstatus/gps1/rtk<br/>GPSRTK"| d66(["/robot_1/interface/mavros/gpsstatus/gps1/rtk (no subscribers)"])
+  n24 -->|"/robot_1/interface/mavros/gpsstatus/gps2/raw<br/>GPSRAW"| d67(["/robot_1/interface/mavros/gpsstatus/gps2/raw (no subscribers)"])
+  n24 -->|"/robot_1/interface/mavros/gpsstatus/gps2/rtk<br/>GPSRTK"| d68(["/robot_1/interface/mavros/gpsstatus/gps2/rtk (no subscribers)"])
+  n26 -->|"/robot_1/interface/mavros/hil/actuator_controls<br/>HilActuatorControls"| d69(["/robot_1/interface/mavros/hil/actuator_controls (no subscribers)"])
+  n26 -->|"/robot_1/interface/mavros/hil/controls<br/>HilControls"| d70(["/robot_1/interface/mavros/hil/controls (no subscribers)"])
+  d71(["/robot_1/interface/mavros/hil/gps (no publishers)"]) -->|"/robot_1/interface/mavros/hil/gps<br/>HilGPS"| n26
+  d72(["/robot_1/interface/mavros/hil/imu_ned (no publishers)"]) -->|"/robot_1/interface/mavros/hil/imu_ned<br/>HilSensor"| n26
+  d73(["/robot_1/interface/mavros/hil/optical_flow (no publishers)"]) -->|"/robot_1/interface/mavros/hil/optical_flow<br/>OpticalFlowRad"| n26
+  d74(["/robot_1/interface/mavros/hil/rc_inputs (no publishers)"]) -->|"/robot_1/interface/mavros/hil/rc_inputs<br/>RCIn"| n26
+  d75(["/robot_1/interface/mavros/hil/state (no publishers)"]) -->|"/robot_1/interface/mavros/hil/state<br/>HilStateQuaternion"| n26
+  n27 -->|"/robot_1/interface/mavros/home_position/home<br/>HomePosition"| n21
+  n27 -->|"/robot_1/interface/mavros/home_position/home<br/>HomePosition"| n70
+  n70 -->|"/robot_1/interface/mavros/home_position/set<br/>HomePosition"| n27
+  n28 -->|"/robot_1/interface/mavros/imu/data<br/>Imu"| d76(["/robot_1/interface/mavros/imu/data (no subscribers)"])
+  n28 -->|"/robot_1/interface/mavros/imu/data_raw<br/>Imu"| d77(["/robot_1/interface/mavros/imu/data_raw (no subscribers)"])
+  n28 -->|"/robot_1/interface/mavros/imu/diff_pressure<br/>FluidPressure"| d78(["/robot_1/interface/mavros/imu/diff_pressure (no subscribers)"])
+  n28 -->|"/robot_1/interface/mavros/imu/mag<br/>MagneticField"| d79(["/robot_1/interface/mavros/imu/mag (no subscribers)"])
+  n28 -->|"/robot_1/interface/mavros/imu/static_pressure<br/>FluidPressure"| d80(["/robot_1/interface/mavros/imu/static_pressure (no subscribers)"])
+  n28 -->|"/robot_1/interface/mavros/imu/temperature_baro<br/>Temperature"| d81(["/robot_1/interface/mavros/imu/temperature_baro (no subscribers)"])
+  n28 -->|"/robot_1/interface/mavros/imu/temperature_imu<br/>Temperature"| d82(["/robot_1/interface/mavros/imu/temperature_imu (no subscribers)"])
+  n29 -->|"/robot_1/interface/mavros/landing_target/lt_marker<br/>Vector3Stamped"| d83(["/robot_1/interface/mavros/landing_target/lt_marker (no subscribers)"])
+  d84(["/robot_1/interface/mavros/landing_target/pose (no publishers)"]) -->|"/robot_1/interface/mavros/landing_target/pose<br/>PoseStamped"| n29
+  n29 -->|"/robot_1/interface/mavros/landing_target/pose_in<br/>PoseStamped"| d85(["/robot_1/interface/mavros/landing_target/pose_in (no subscribers)"])
+  n30 -->|"/robot_1/interface/mavros/local_position/accel<br/>AccelWithCovarianceStamped"| d86(["/robot_1/interface/mavros/local_position/accel (no subscribers)"])
+  n30 -->|"/robot_1/interface/mavros/local_position/odom<br/>Odometry"| n71
+  n30 -->|"/robot_1/interface/mavros/local_position/pose<br/>PoseStamped"| n54
+  n30 -->|"/robot_1/interface/mavros/local_position/pose_cov<br/>PoseWithCovarianceStamped"| d87(["/robot_1/interface/mavros/local_position/pose_cov (no subscribers)"])
+  n30 -->|"/robot_1/interface/mavros/local_position/velocity_body<br/>TwistStamped"| d88(["/robot_1/interface/mavros/local_position/velocity_body (no subscribers)"])
+  n30 -->|"/robot_1/interface/mavros/local_position/velocity_body_cov<br/>TwistWithCovarianceStamped"| d89(["/robot_1/interface/mavros/local_position/velocity_body_cov (no subscribers)"])
+  n30 -->|"/robot_1/interface/mavros/local_position/velocity_local<br/>TwistStamped"| d90(["/robot_1/interface/mavros/local_position/velocity_local (no subscribers)"])
+  n31 -->|"/robot_1/interface/mavros/log_transfer/raw/log_data<br/>LogData"| d91(["/robot_1/interface/mavros/log_transfer/raw/log_data (no subscribers)"])
+  n31 -->|"/robot_1/interface/mavros/log_transfer/raw/log_entry<br/>LogEntry"| d92(["/robot_1/interface/mavros/log_transfer/raw/log_entry (no subscribers)"])
+  n32 -->|"/robot_1/interface/mavros/mag_calibration/report<br/>MagnetometerReporter"| d93(["/robot_1/interface/mavros/mag_calibration/report (no subscribers)"])
+  n32 -->|"/robot_1/interface/mavros/mag_calibration/status<br/>UInt8"| d94(["/robot_1/interface/mavros/mag_calibration/status (no subscribers)"])
+  n33 -->|"/robot_1/interface/mavros/manual_control/control<br/>ManualControl"| d95(["/robot_1/interface/mavros/manual_control/control (no subscribers)"])
+  d96(["/robot_1/interface/mavros/manual_control/send (no publishers)"]) -->|"/robot_1/interface/mavros/manual_control/send<br/>ManualControl"| n33
+  n37 -->|"/robot_1/interface/mavros/mission/reached<br/>WaypointReached"| d97(["/robot_1/interface/mavros/mission/reached (no subscribers)"])
+  n37 -->|"/robot_1/interface/mavros/mission/waypoints<br/>WaypointList"| d98(["/robot_1/interface/mavros/mission/waypoints (no subscribers)"])
+  d99(["/robot_1/interface/mavros/mocap/pose (no publishers)"]) -->|"/robot_1/interface/mavros/mocap/pose<br/>PoseStamped"| n38
+  d100(["/robot_1/interface/mavros/mocap/tf (no publishers)"]) -->|"/robot_1/interface/mavros/mocap/tf<br/>TransformStamped"| n38
+  d101(["/robot_1/interface/mavros/mount_control/command (no publishers)"]) -->|"/robot_1/interface/mavros/mount_control/command<br/>MountControl"| n39
+  n39 -->|"/robot_1/interface/mavros/mount_control/orientation<br/>Quaternion"| d102(["/robot_1/interface/mavros/mount_control/orientation (no subscribers)"])
+  n39 -->|"/robot_1/interface/mavros/mount_control/status<br/>Vector3Stamped"| d103(["/robot_1/interface/mavros/mount_control/status (no subscribers)"])
+  n40 -->|"/robot_1/interface/mavros/nav_controller_output/output<br/>NavControllerOutput"| d104(["/robot_1/interface/mavros/nav_controller_output/output (no subscribers)"])
+  d105(["/robot_1/interface/mavros/obstacle/send (no publishers)"]) -->|"/robot_1/interface/mavros/obstacle/send<br/>LaserScan"| n41
+  d106(["/robot_1/interface/mavros/obstacle_distance_3d/send (no publishers)"]) -->|"/robot_1/interface/mavros/obstacle_distance_3d/send<br/>ObstacleDistance3D"| n42
+  n43 -->|"/robot_1/interface/mavros/odometry/in<br/>Odometry"| d107(["/robot_1/interface/mavros/odometry/in (no subscribers)"])
+  d108(["/robot_1/interface/mavros/odometry/out (no publishers)"]) -->|"/robot_1/interface/mavros/odometry/out<br/>Odometry"| n43
+  d109(["/robot_1/interface/mavros/onboard_computer/status (no publishers)"]) -->|"/robot_1/interface/mavros/onboard_computer/status<br/>OnboardComputerStatus"| n44
+  d110(["/robot_1/interface/mavros/open_drone_id/basic_id (no publishers)"]) -->|"/robot_1/interface/mavros/open_drone_id/basic_id<br/>OpenDroneIDBasicID"| n45
+  d111(["/robot_1/interface/mavros/open_drone_id/operator_id (no publishers)"]) -->|"/robot_1/interface/mavros/open_drone_id/operator_id<br/>OpenDroneIDOperatorID"| n45
+  d112(["/robot_1/interface/mavros/open_drone_id/self_id (no publishers)"]) -->|"/robot_1/interface/mavros/open_drone_id/self_id<br/>OpenDroneIDSelfID"| n45
+  d113(["/robot_1/interface/mavros/open_drone_id/system (no publishers)"]) -->|"/robot_1/interface/mavros/open_drone_id/system<br/>OpenDroneIDSystem"| n45
+  d114(["/robot_1/interface/mavros/open_drone_id/system_update (no publishers)"]) -->|"/robot_1/interface/mavros/open_drone_id/system_update<br/>OpenDroneIDSystemUpdate"| n45
+  n46 -->|"/robot_1/interface/mavros/optical_flow/ground_distance<br/>Range"| d115(["/robot_1/interface/mavros/optical_flow/ground_distance (no subscribers)"])
+  n46 -->|"/robot_1/interface/mavros/optical_flow/raw/optical_flow<br/>OpticalFlow"| d116(["/robot_1/interface/mavros/optical_flow/raw/optical_flow (no subscribers)"])
+  d117(["/robot_1/interface/mavros/optical_flow/raw/send (no publishers)"]) -->|"/robot_1/interface/mavros/optical_flow/raw/send<br/>OpticalFlow"| n46
+  n47 -->|"/robot_1/interface/mavros/param/event<br/>ParamEvent"| d118(["/robot_1/interface/mavros/param/event (no subscribers)"])
+  d119(["/robot_1/interface/mavros/play_tune (no publishers)"]) -->|"/robot_1/interface/mavros/play_tune<br/>PlayTuneV2"| n48
+  n49 -->|"/robot_1/interface/mavros/px4flow/ground_distance<br/>Range"| d120(["/robot_1/interface/mavros/px4flow/ground_distance (no subscribers)"])
+  n49 -->|"/robot_1/interface/mavros/px4flow/raw/optical_flow_rad<br/>OpticalFlowRad"| d121(["/robot_1/interface/mavros/px4flow/raw/optical_flow_rad (no subscribers)"])
+  d122(["/robot_1/interface/mavros/px4flow/raw/send (no publishers)"]) -->|"/robot_1/interface/mavros/px4flow/raw/send<br/>OpticalFlowRad"| n49
+  n49 -->|"/robot_1/interface/mavros/px4flow/temperature<br/>Temperature"| d123(["/robot_1/interface/mavros/px4flow/temperature (no subscribers)"])
+  n60 -->|"/robot_1/interface/mavros/radio_status<br/>RadioStatus"| d124(["/robot_1/interface/mavros/radio_status (no subscribers)"])
+  n50 -->|"/robot_1/interface/mavros/rallypoint/rallypoints<br/>WaypointList"| d125(["/robot_1/interface/mavros/rallypoint/rallypoints (no subscribers)"])
+  n51 -->|"/robot_1/interface/mavros/rc/in<br/>RCIn"| d126(["/robot_1/interface/mavros/rc/in (no subscribers)"])
+  n51 -->|"/robot_1/interface/mavros/rc/out<br/>RCOut"| d127(["/robot_1/interface/mavros/rc/out (no subscribers)"])
+  d128(["/robot_1/interface/mavros/rc/override (no publishers)"]) -->|"/robot_1/interface/mavros/rc/override<br/>OverrideRCIn"| n51
+  d129(["/robot_1/interface/mavros/setpoint_accel/accel (no publishers)"]) -->|"/robot_1/interface/mavros/setpoint_accel/accel<br/>Vector3Stamped"| n52
+  d130(["/robot_1/interface/mavros/setpoint_attitude/cmd_vel (no publishers)"]) -->|"/robot_1/interface/mavros/setpoint_attitude/cmd_vel<br/>TwistStamped"| n53
+  d131(["/robot_1/interface/mavros/setpoint_attitude/thrust (no publishers)"]) -->|"/robot_1/interface/mavros/setpoint_attitude/thrust<br/>Thrust"| n53
+  n70 -->|"/robot_1/interface/mavros/setpoint_position/global<br/>GeoPoseStamped"| n54
+  d132(["/robot_1/interface/mavros/setpoint_position/global_to_local (no publishers)"]) -->|"/robot_1/interface/mavros/setpoint_position/global_to_local<br/>GeoPoseStamped"| n54
+  n70 -->|"/robot_1/interface/mavros/setpoint_position/local<br/>PoseStamped"| n54
+  n70 -->|"/robot_1/interface/mavros/setpoint_raw/attitude<br/>AttitudeTarget"| n55
+  d133(["/robot_1/interface/mavros/setpoint_raw/global (no publishers)"]) -->|"/robot_1/interface/mavros/setpoint_raw/global<br/>GlobalPositionTarget"| n55
+  n70 -->|"/robot_1/interface/mavros/setpoint_raw/local<br/>PositionTarget"| n55
+  n55 -->|"/robot_1/interface/mavros/setpoint_raw/target_attitude<br/>AttitudeTarget"| d134(["/robot_1/interface/mavros/setpoint_raw/target_attitude (no subscribers)"])
+  n55 -->|"/robot_1/interface/mavros/setpoint_raw/target_global<br/>GlobalPositionTarget"| d135(["/robot_1/interface/mavros/setpoint_raw/target_global (no subscribers)"])
+  n55 -->|"/robot_1/interface/mavros/setpoint_raw/target_local<br/>PositionTarget"| d136(["/robot_1/interface/mavros/setpoint_raw/target_local (no subscribers)"])
+  n56 -->|"/robot_1/interface/mavros/setpoint_trajectory/desired<br/>Path"| d137(["/robot_1/interface/mavros/setpoint_trajectory/desired (no subscribers)"])
+  d138(["/robot_1/interface/mavros/setpoint_trajectory/local (no publishers)"]) -->|"/robot_1/interface/mavros/setpoint_trajectory/local<br/>MultiDOFJointTrajectory"| n56
+  d139(["/robot_1/interface/mavros/setpoint_velocity/cmd_vel (no publishers)"]) -->|"/robot_1/interface/mavros/setpoint_velocity/cmd_vel<br/>TwistStamped"| n57
+  d140(["/robot_1/interface/mavros/setpoint_velocity/cmd_vel_unstamped (no publishers)"]) -->|"/robot_1/interface/mavros/setpoint_velocity/cmd_vel_unstamped<br/>Twist"| n57
+  n58 -->|"/robot_1/interface/mavros/sim_state/acceleration<br/>Vector3Stamped"| d141(["/robot_1/interface/mavros/sim_state/acceleration (no subscribers)"])
+  n58 -->|"/robot_1/interface/mavros/sim_state/attitude<br/>Imu"| d142(["/robot_1/interface/mavros/sim_state/attitude (no subscribers)"])
+  n58 -->|"/robot_1/interface/mavros/sim_state/global_position<br/>NavSatFix"| d143(["/robot_1/interface/mavros/sim_state/global_position (no subscribers)"])
+  n58 -->|"/robot_1/interface/mavros/sim_state/velocity_body<br/>TwistStamped"| d144(["/robot_1/interface/mavros/sim_state/velocity_body (no subscribers)"])
+  n58 -->|"/robot_1/interface/mavros/sim_state/velocity_local<br/>TwistStamped"| d145(["/robot_1/interface/mavros/sim_state/velocity_local (no subscribers)"])
+  n59 -->|"/robot_1/interface/mavros/state<br/>State"| n70
+  n59 -->|"/robot_1/interface/mavros/status_event<br/>StatusEvent"| d146(["/robot_1/interface/mavros/status_event (no subscribers)"])
+  n59 -->|"/robot_1/interface/mavros/statustext/recv<br/>StatusText"| d147(["/robot_1/interface/mavros/statustext/recv (no subscribers)"])
+  d148(["/robot_1/interface/mavros/statustext/send (no publishers)"]) -->|"/robot_1/interface/mavros/statustext/send<br/>StatusText"| n59
+  n59 -->|"/robot_1/interface/mavros/sys_status<br/>SysStatus"| d149(["/robot_1/interface/mavros/sys_status (no subscribers)"])
+  n6 -->|"/robot_1/interface/mavros/target_actuator_control<br/>ActuatorControl"| d150(["/robot_1/interface/mavros/target_actuator_control (no subscribers)"])
+  n61 -->|"/robot_1/interface/mavros/terrain/report<br/>TerrainReport"| d151(["/robot_1/interface/mavros/terrain/report (no subscribers)"])
+  n62 -->|"/robot_1/interface/mavros/time_reference<br/>TimeReference"| d152(["/robot_1/interface/mavros/time_reference (no subscribers)"])
+  n62 -->|"/robot_1/interface/mavros/timesync_status<br/>TimesyncStatus"| d153(["/robot_1/interface/mavros/timesync_status (no subscribers)"])
+  n63 -->|"/robot_1/interface/mavros/trajectory/desired<br/>Trajectory"| d154(["/robot_1/interface/mavros/trajectory/desired (no subscribers)"])
+  d155(["/robot_1/interface/mavros/trajectory/generated (no publishers)"]) -->|"/robot_1/interface/mavros/trajectory/generated<br/>Trajectory"| n63
+  d156(["/robot_1/interface/mavros/trajectory/path (no publishers)"]) -->|"/robot_1/interface/mavros/trajectory/path<br/>Path"| n63
+  d157(["/robot_1/interface/mavros/tunnel/in (no publishers)"]) -->|"/robot_1/interface/mavros/tunnel/in<br/>Tunnel"| n64
+  n64 -->|"/robot_1/interface/mavros/tunnel/out<br/>Tunnel"| d158(["/robot_1/interface/mavros/tunnel/out (no subscribers)"])
+  n65 -->|"/robot_1/interface/mavros/vfr_hud<br/>VfrHud"| d159(["/robot_1/interface/mavros/vfr_hud (no subscribers)"])
+  d160(["/robot_1/interface/mavros/vision_pose/pose (no publishers)"]) -->|"/robot_1/interface/mavros/vision_pose/pose<br/>PoseStamped"| n66
+  d161(["/robot_1/interface/mavros/vision_pose/pose_cov (no publishers)"]) -->|"/robot_1/interface/mavros/vision_pose/pose_cov<br/>PoseWithCovarianceStamped"| n66
+  d162(["/robot_1/interface/mavros/vision_speed/speed_twist (no publishers)"]) -->|"/robot_1/interface/mavros/vision_speed/speed_twist<br/>TwistStamped"| n67
+  d163(["/robot_1/interface/mavros/vision_speed/speed_twist_cov (no publishers)"]) -->|"/robot_1/interface/mavros/vision_speed/speed_twist_cov<br/>TwistWithCovarianceStamped"| n67
+  d164(["/robot_1/interface/mavros/vision_speed/speed_vector (no publishers)"]) -->|"/robot_1/interface/mavros/vision_speed/speed_vector<br/>Vector3Stamped"| n67
+  n68 -->|"/robot_1/interface/mavros/wind_estimation<br/>TwistWithCovarianceStamped"| d165(["/robot_1/interface/mavros/wind_estimation (no subscribers)"])
+  d166(["/robot_1/interface/pose_command (no publishers)"]) -->|"/robot_1/interface/pose_command<br/>PoseStamped"| n70
+  d167(["/robot_1/interface/rate_thrust_command (no publishers)"]) -->|"/robot_1/interface/rate_thrust_command<br/>RateThrust"| n70
+  d168(["/robot_1/interface/roll_pitch_yawrate_thrust_command (no publishers)"]) -->|"/robot_1/interface/roll_pitch_yawrate_thrust_command<br/>RollPitchYawrateThrust"| n70
+  d169(["/robot_1/interface/torque_thrust_command (no publishers)"]) -->|"/robot_1/interface/torque_thrust_command<br/>TorqueThrust"| n70
+  d170(["/robot_1/interface/velocity_command (no publishers)"]) -->|"/robot_1/interface/velocity_command<br/>TwistStamped"| n70
+  d171(["/robot_1/joint_states (no publishers)"]) -->|"/robot_1/joint_states<br/>JointState"| n75
+  d172(["/robot_1/macvo/odometry (no publishers)"]) -->|"/robot_1/macvo/odometry<br/>Odometry"| n78
+  n71 -->|"/robot_1/odometry_conversion/odometry<br/>Odometry"| n2
+  n71 -->|"/robot_1/odometry_conversion/odometry<br/>Odometry"| n3
+  n71 -->|"/robot_1/odometry_conversion/odometry<br/>Odometry"| n69
+  n71 -->|"/robot_1/odometry_conversion/odometry<br/>Odometry"| n74
+  n71 -->|"/robot_1/odometry_conversion/odometry<br/>Odometry"| n77
+  n71 -->|"/robot_1/odometry_conversion/odometry<br/>Odometry"| n78
+  n71 -->|"/robot_1/odometry_conversion/odometry<br/>Odometry"| n79
+  n71 -->|"/robot_1/odometry_conversion/odometry<br/>Odometry"| n80
+  d173(["/robot_1/perception/macvo/disparity (no publishers)"]) -->|"/robot_1/perception/macvo/disparity<br/>Image"| n78
+  d174(["/robot_1/perception/macvo/point_cloud (no publishers)"]) -->|"/robot_1/perception/macvo/point_cloud<br/>PointCloud"| n78
+  n72 -->|"/robot_1/perception/stereo_image_proc/disparity<br/>DisparityImage"| n4
+  n72 -->|"/robot_1/perception/stereo_image_proc/disparity<br/>DisparityImage"| n73
+  n73 -->|"/robot_1/perception/stereo_image_proc/point_cloud<br/>PointCloud2"| n78
+  n74 -->|"/robot_1/random_walk_node/goal_point_viz<br/>Marker"| d175(["/robot_1/random_walk_node/goal_point_viz (no subscribers)"])
+  n74 -->|"/robot_1/random_walk_node/traj_viz<br/>Marker"| d176(["/robot_1/random_walk_node/traj_viz (no subscribers)"])
+  n75 -->|"/robot_1/robot_description<br/>String"| d177(["/robot_1/robot_description (no subscribers)"])
+  d178(["/robot_1/sensors/front_stereo/left/camera_info (no publishers)"]) -->|"/robot_1/sensors/front_stereo/left/camera_info<br/>CameraInfo"| n72
+  d178 -->|"/robot_1/sensors/front_stereo/left/camera_info<br/>CameraInfo"| n73
+  d178 -->|"/robot_1/sensors/front_stereo/left/camera_info<br/>CameraInfo"| n78
+  d179(["/robot_1/sensors/front_stereo/left/depth_ground_truth (no publishers)"]) -->|"/robot_1/sensors/front_stereo/left/depth_ground_truth<br/>Image"| n78
+  d180(["/robot_1/sensors/front_stereo/left/image_rect (no publishers)"]) -->|"/robot_1/sensors/front_stereo/left/image_rect<br/>Image"| n72
+  d180 -->|"/robot_1/sensors/front_stereo/left/image_rect<br/>Image"| n73
+  d180 -->|"/robot_1/sensors/front_stereo/left/image_rect<br/>Image"| n78
+  d181(["/robot_1/sensors/front_stereo/right/camera_info (no publishers)"]) -->|"/robot_1/sensors/front_stereo/right/camera_info<br/>CameraInfo"| n4
+  d181 -->|"/robot_1/sensors/front_stereo/right/camera_info<br/>CameraInfo"| n72
+  d181 -->|"/robot_1/sensors/front_stereo/right/camera_info<br/>CameraInfo"| n73
+  d181 -->|"/robot_1/sensors/front_stereo/right/camera_info<br/>CameraInfo"| n78
+  d182(["/robot_1/sensors/front_stereo/right/depth_ground_truth (no publishers)"]) -->|"/robot_1/sensors/front_stereo/right/depth_ground_truth<br/>Image"| n78
+  d183(["/robot_1/sensors/front_stereo/right/image_rect (no publishers)"]) -->|"/robot_1/sensors/front_stereo/right/image_rect<br/>Image"| n72
+  d183 -->|"/robot_1/sensors/front_stereo/right/image_rect<br/>Image"| n78
+  d184(["/robot_1/sensors/lidar/point_cloud (no publishers)"]) -->|"/robot_1/sensors/lidar/point_cloud<br/>PointCloud2"| n78
+  n76 -->|"/robot_1/sensors/ouster/point_cloud<br/>PointCloud2"| n81
+  d185(["/robot_1/sensors/ouster/point_cloud_raw (no publishers)"]) -->|"/robot_1/sensors/ouster/point_cloud_raw<br/>PointCloud2"| n76
+  n77 -->|"/robot_1/takeoff_landing_planner/is_airborne<br/>Bool"| d186(["/robot_1/takeoff_landing_planner/is_airborne (no subscribers)"])
+  d187(["/robot_1/takeoff_landing_planner/trajectory_completion_percentage (no publishers)"]) -->|"/robot_1/takeoff_landing_planner/trajectory_completion_percentage<br/>Float32"| n77
+  n80 -->|"/robot_1/trajectory_controller/closest_point<br/>Odometry"| d188(["/robot_1/trajectory_controller/closest_point (no subscribers)"])
+  n80 -->|"/robot_1/trajectory_controller/look_ahead<br/>Odometry"| n4
+  n80 -->|"/robot_1/trajectory_controller/projected_drone_pose<br/>PoseStamped"| n69
+  n80 -->|"/robot_1/trajectory_controller/tracking_error<br/>Float32"| d189(["/robot_1/trajectory_controller/tracking_error (no subscribers)"])
+  n80 -->|"/robot_1/trajectory_controller/tracking_point<br/>Odometry"| n3
+  n80 -->|"/robot_1/trajectory_controller/tracking_point<br/>Odometry"| n4
+  n80 -->|"/robot_1/trajectory_controller/tracking_point<br/>Odometry"| n69
+  n80 -->|"/robot_1/trajectory_controller/tracking_point<br/>Odometry"| n77
+  n80 -->|"/robot_1/trajectory_controller/tracking_point_velocity_magnitude<br/>Float32"| d190(["/robot_1/trajectory_controller/tracking_point_velocity_magnitude (no subscribers)"])
+  n80 -->|"/robot_1/trajectory_controller/traj_drone_point<br/>Odometry"| d191(["/robot_1/trajectory_controller/traj_drone_point (no subscribers)"])
+  n80 -->|"/robot_1/trajectory_controller/trajectory_completion_percentage<br/>Float32"| n79
+  n80 -->|"/robot_1/trajectory_controller/trajectory_controller_debug_markers<br/>MarkerArray"| n78
+  n77 -->|"/robot_1/trajectory_controller/trajectory_override<br/>TrajectoryXYZVYaw"| n80
+  n79 -->|"/robot_1/trajectory_controller/trajectory_override<br/>TrajectoryXYZVYaw"| n80
+  n4 -->|"/robot_1/trajectory_controller/trajectory_segment_to_add<br/>TrajectoryXYZVYaw"| n80
+  n80 -->|"/robot_1/trajectory_controller/trajectory_time<br/>Float32"| d192(["/robot_1/trajectory_controller/trajectory_time (no subscribers)"])
+  n80 -->|"/robot_1/trajectory_controller/trajectory_vis<br/>MarkerArray"| n78
+  n80 -->|"/robot_1/trajectory_controller/virtual_tracking_point<br/>Odometry"| d193(["/robot_1/trajectory_controller/virtual_tracking_point (no subscribers)"])
+  n81 -->|"/robot_1/vdb_mapping/vdb_map_overwrites<br/>UpdateGrid"| d194(["/robot_1/vdb_mapping/vdb_map_overwrites (no subscribers)"])
+  n81 -->|"/robot_1/vdb_mapping/vdb_map_pointcloud<br/>PointCloud2"| d195(["/robot_1/vdb_mapping/vdb_map_pointcloud (no subscribers)"])
+  n81 -->|"/robot_1/vdb_mapping/vdb_map_sections<br/>UpdateGrid"| d196(["/robot_1/vdb_mapping/vdb_map_sections (no subscribers)"])
+  n81 -->|"/robot_1/vdb_mapping/vdb_map_updates<br/>UpdateGrid"| d197(["/robot_1/vdb_mapping/vdb_map_updates (no subscribers)"])
+  n81 -->|"/robot_1/vdb_mapping/vdb_map_visualization<br/>Marker"| n74
+  n81 -->|"/robot_1/vdb_mapping/vdb_map_visualization<br/>Marker"| n78
+  n34 -->|"/tf<br/>TFMessage"| n69
+  n34 -->|"/tf<br/>TFMessage"| n78
+  n71 -->|"/tf<br/>TFMessage"| n69
+  n71 -->|"/tf<br/>TFMessage"| n78
+  n75 -->|"/tf<br/>TFMessage"| n69
+  n75 -->|"/tf<br/>TFMessage"| n78
+  n80 -->|"/tf<br/>TFMessage"| n69
+  n80 -->|"/tf<br/>TFMessage"| n78
+  n34 -->|"/tf_static<br/>TFMessage"| n69
+  n34 -->|"/tf_static<br/>TFMessage"| n78
+  n75 -->|"/tf_static<br/>TFMessage"| n69
+  n75 -->|"/tf_static<br/>TFMessage"| n78
+  n82 -->|"/tf_static<br/>TFMessage"| n69
+  n82 -->|"/tf_static<br/>TFMessage"| n78
+  n34 -->|"/uas2/mavlink_sink<br/>Mavlink"| n36
+  n36 -->|"/uas2/mavlink_source<br/>Mavlink"| n34
+```
+
+<!-- wiring-graph-v1
+{
+"edges": [
+{
+"dir": "sub",
+"node": "/robot_1/Container",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/behavior/drone_safety_monitor/drone_safety_monitor",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/control/pid_controller",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/gossip_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/actuator_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/adsb",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/altitude",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/cam_imu_sync",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/camera",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/cellular_status",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/cmd",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/companion_process",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/debug_value",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/esc_status",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/esc_telemetry",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/fake_gps",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/ftp",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/geofence",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/gimbal_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/global_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/gps_input",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/gps_rtk",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/gpsstatus",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/guided_target",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/hil",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/home_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/imu",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/landing_target",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/local_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/log_transfer",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/mag_calibration",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/manual_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/mavros",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/mavros_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/mavros_router",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/mission",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/mocap",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/mount_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/nav_controller_output",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/obstacle",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/obstacle_distance_3d",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/odometry",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/onboard_computer",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/open_drone_id",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/optical_flow",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/param",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/play_tune",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/px4flow",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/rallypoint",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/rc",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_accel",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_attitude",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_raw",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_trajectory",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_velocity",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/sim_state",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/sys",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/tdr_radio",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/terrain",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/time",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/trajectory",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/tunnel",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/vfr_hud",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/vision_pose",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/vision_speed",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/wind",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/odom_modifier",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/odometry_conversion/odometry_conversion",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/perception/stereo_image_proc/disparity_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/perception/stereo_pointcloud",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/random_walk_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/robot_state_publisher",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/sensors/lidar_point_cloud_filter",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/takeoff_landing_planner/takeoff_landing_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/trajectory_controller/fixed_trajectory_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/vdb_mapping",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "sub",
+"node": "/robot_1/world_to_map_broadcaster",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/clock",
+"type": "rosgraph_msgs/msg/Clock"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/mavros",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/diagnostics",
+"type": "diagnostic_msgs/msg/DiagnosticArray"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/mavros_router",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/diagnostics",
+"type": "diagnostic_msgs/msg/DiagnosticArray"
+},
+{
+"dir": "pub",
+"node": "/robot_1/gossip_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/gossip/peers",
+"type": "coordination_msgs/msg/PeerProfile"
+},
+{
+"dir": "sub",
+"node": "/robot_1/gossip_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/gossip/peers",
+"type": "coordination_msgs/msg/PeerProfile"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/guided_target",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/move_base_simple/goal",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/behavior/drone_safety_monitor/drone_safety_monitor",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/behavior/drone_safety_monitor/command",
+"type": "std_msgs/msg/String"
+},
+{
+"dir": "pub",
+"node": "/robot_1/behavior/drone_safety_monitor/drone_safety_monitor",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/behavior/drone_safety_monitor/state_estimate_timed_out",
+"type": "std_msgs/msg/Bool"
+},
+{
+"dir": "sub",
+"node": "/robot_1/takeoff_landing_planner/takeoff_landing_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/behavior/drone_safety_monitor/state_estimate_timed_out",
+"type": "std_msgs/msg/Bool"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/control/reset_integrators",
+"type": "std_msgs/msg/Empty"
+},
+{
+"dir": "sub",
+"node": "/robot_1/control/pid_controller",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/control/reset_integrators",
+"type": "std_msgs/msg/Empty"
+},
+{
+"dir": "pub",
+"node": "/robot_1/control/pid_controller",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/control/vx_pid_info",
+"type": "pid_controller_msgs/msg/PIDInfo"
+},
+{
+"dir": "pub",
+"node": "/robot_1/control/pid_controller",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/control/vy_pid_info",
+"type": "pid_controller_msgs/msg/PIDInfo"
+},
+{
+"dir": "pub",
+"node": "/robot_1/control/pid_controller",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/control/vz_pid_info",
+"type": "pid_controller_msgs/msg/PIDInfo"
+},
+{
+"dir": "pub",
+"node": "/robot_1/control/pid_controller",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/control/x_pid_info",
+"type": "pid_controller_msgs/msg/PIDInfo"
+},
+{
+"dir": "pub",
+"node": "/robot_1/control/pid_controller",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/control/y_pid_info",
+"type": "pid_controller_msgs/msg/PIDInfo"
+},
+{
+"dir": "pub",
+"node": "/robot_1/control/pid_controller",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/control/z_pid_info",
+"type": "pid_controller_msgs/msg/PIDInfo"
+},
+{
+"dir": "pub",
+"node": "/robot_1/gossip_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/coordination/peer_registry",
+"type": "coordination_msgs/msg/PeerProfile"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/odom_modifier",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/cross_track_error",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/background_expanded",
+"type": "sensor_msgs/msg/Image"
+},
+{
+"dir": "sub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/clear_map",
+"type": "std_msgs/msg/Empty"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/disparity_graph",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/disparity_map_debug",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/droan/expansion_cloud",
+"type": "sensor_msgs/msg/PointCloud2"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/expansion_poly",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "pub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/fg_bg_cloud",
+"type": "sensor_msgs/msg/PointCloud2"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/droan/fg_bg_cloud",
+"type": "sensor_msgs/msg/PointCloud2"
+},
+{
+"dir": "pub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/foreground_expanded",
+"type": "sensor_msgs/msg/Image"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/frustum",
+"type": "visualization_msgs/msg/Marker"
+},
+{
+"dir": "pub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/graph_vis",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/graph_vis",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "pub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/local_planner_global_plan_vis",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/local_planner_global_plan_vis",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "sub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/reset_stuck",
+"type": "std_msgs/msg/Empty"
+},
+{
+"dir": "pub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/rewind_info",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/rewind_info",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "pub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/stuck",
+"type": "std_msgs/msg/Bool"
+},
+{
+"dir": "pub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/traj_debug",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/traj_debug",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/trajectory_library_vis",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/droan/virtual_obstacles",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/odom_modifier",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/global_plan",
+"type": "nav_msgs/msg/Path"
+},
+{
+"dir": "pub",
+"node": "/robot_1/random_walk_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/global_plan",
+"type": "nav_msgs/msg/Path"
+},
+{
+"dir": "sub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/global_plan",
+"type": "nav_msgs/msg/Path"
+},
+{
+"dir": "sub",
+"node": "/robot_1/gossip_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/global_plan",
+"type": "nav_msgs/msg/Path"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/global_plan",
+"type": "nav_msgs/msg/Path"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/attitude_thrust_command",
+"type": "mav_msgs/msg/AttitudeThrust"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/cmd_attitude_thrust",
+"type": "mav_msgs/msg/AttitudeThrust"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/odom_modifier",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/cmd_pose",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/cmd_pose",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/cmd_rate_thrust",
+"type": "mav_msgs/msg/RateThrust"
+},
+{
+"dir": "pub",
+"node": "/robot_1/control/pid_controller",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/cmd_roll_pitch_yawrate_thrust",
+"type": "mav_msgs/msg/RollPitchYawrateThrust"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/cmd_roll_pitch_yawrate_thrust",
+"type": "mav_msgs/msg/RollPitchYawrateThrust"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/cmd_torque_thrust",
+"type": "mav_msgs/msg/TorqueThrust"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/odom_modifier",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/cmd_velocity",
+"type": "geometry_msgs/msg/TwistStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/cmd_velocity",
+"type": "geometry_msgs/msg/TwistStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/has_control",
+"type": "std_msgs/msg/Bool"
+},
+{
+"dir": "sub",
+"node": "/robot_1/takeoff_landing_planner/takeoff_landing_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/has_control",
+"type": "std_msgs/msg/Bool"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/is_armed",
+"type": "std_msgs/msg/Bool"
+},
+{
+"dir": "sub",
+"node": "/robot_1/takeoff_landing_planner/takeoff_landing_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/is_armed",
+"type": "std_msgs/msg/Bool"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/actuator_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/actuator_control",
+"type": "mavros_msgs/msg/ActuatorControl"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/adsb",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/adsb/send",
+"type": "mavros_msgs/msg/ADSBVehicle"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/adsb",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/adsb/vehicle",
+"type": "mavros_msgs/msg/ADSBVehicle"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/altitude",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/altitude",
+"type": "mavros_msgs/msg/Altitude"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/sys",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/battery",
+"type": "sensor_msgs/msg/BatteryState"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/cam_imu_sync",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/cam_imu_sync/cam_imu_stamp",
+"type": "mavros_msgs/msg/CamIMUStamp"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/camera",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/camera/image_captured",
+"type": "mavros_msgs/msg/CameraImageCaptured"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/cellular_status",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/cellular_status/status",
+"type": "mavros_msgs/msg/CellularStatus"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/companion_process",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/companion_process/status",
+"type": "mavros_msgs/msg/CompanionProcessStatus"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/debug_value",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/debug_value/debug",
+"type": "mavros_msgs/msg/DebugValue"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/debug_value",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/debug_value/debug_float_array",
+"type": "mavros_msgs/msg/DebugValue"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/debug_value",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/debug_value/debug_vector",
+"type": "mavros_msgs/msg/DebugValue"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/debug_value",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/debug_value/named_value_float",
+"type": "mavros_msgs/msg/DebugValue"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/debug_value",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/debug_value/named_value_int",
+"type": "mavros_msgs/msg/DebugValue"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/debug_value",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/debug_value/send",
+"type": "mavros_msgs/msg/DebugValue"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/esc_status",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/esc_status/info",
+"type": "mavros_msgs/msg/ESCInfo"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/esc_status",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/esc_status/status",
+"type": "mavros_msgs/msg/ESCStatus"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/esc_telemetry",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/esc_telemetry/telemetry",
+"type": "mavros_msgs/msg/ESCTelemetry"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/sys",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/estimator_status",
+"type": "mavros_msgs/msg/EstimatorStatus"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/sys",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/extended_state",
+"type": "mavros_msgs/msg/ExtendedState"
+},
+{
+"dir": "sub",
+"node": "/robot_1/takeoff_landing_planner/takeoff_landing_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/extended_state",
+"type": "mavros_msgs/msg/ExtendedState"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/fake_gps",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/fake_gps/mocap/tf",
+"type": "geometry_msgs/msg/TransformStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/geofence",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/geofence/fences",
+"type": "mavros_msgs/msg/WaypointList"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/gimbal_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gimbal_control/device/attitude_status",
+"type": "mavros_msgs/msg/GimbalDeviceAttitudeStatus"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/gimbal_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gimbal_control/device/info",
+"type": "mavros_msgs/msg/GimbalDeviceInformation"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/gimbal_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gimbal_control/device/set_attitude",
+"type": "mavros_msgs/msg/GimbalDeviceSetAttitude"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/gimbal_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gimbal_control/manager/info",
+"type": "mavros_msgs/msg/GimbalManagerInformation"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/gimbal_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gimbal_control/manager/set_attitude",
+"type": "mavros_msgs/msg/GimbalManagerSetAttitude"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/gimbal_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gimbal_control/manager/set_manual_control",
+"type": "mavros_msgs/msg/GimbalManagerSetPitchyaw"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/gimbal_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gimbal_control/manager/set_pitchyaw",
+"type": "mavros_msgs/msg/GimbalManagerSetPitchyaw"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/gimbal_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gimbal_control/manager/status",
+"type": "mavros_msgs/msg/GimbalManagerStatus"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/global_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/compass_hdg",
+"type": "std_msgs/msg/Float64"
+},
+{
+"dir": "sub",
+"node": "/robot_1/gossip_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/compass_hdg",
+"type": "std_msgs/msg/Float64"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/global_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/global",
+"type": "sensor_msgs/msg/NavSatFix"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/global",
+"type": "sensor_msgs/msg/NavSatFix"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/global",
+"type": "sensor_msgs/msg/NavSatFix"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/global_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/gp_lp_offset",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/global_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/global_position/gp_origin",
+"type": "geographic_msgs/msg/GeoPointStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/guided_target",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/global_position/gp_origin",
+"type": "geographic_msgs/msg/GeoPointStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/global_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/local",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/local",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/global_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/raw/fix",
+"type": "sensor_msgs/msg/NavSatFix"
+},
+{
+"dir": "sub",
+"node": "/robot_1/gossip_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/raw/fix",
+"type": "sensor_msgs/msg/NavSatFix"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/global_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/raw/gps_vel",
+"type": "geometry_msgs/msg/TwistStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/global_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/raw/satellites",
+"type": "std_msgs/msg/UInt32"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/global_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/rel_alt",
+"type": "std_msgs/msg/Float64"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/global_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/global_position/set_gp_origin",
+"type": "geographic_msgs/msg/GeoPointStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/gps_input",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gps_input/gps_input",
+"type": "mavros_msgs/msg/GPSINPUT"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/gps_rtk",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gps_rtk/rtk_baseline",
+"type": "mavros_msgs/msg/RTKBaseline"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/gps_rtk",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gps_rtk/send_rtcm",
+"type": "mavros_msgs/msg/RTCM"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/gpsstatus",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gpsstatus/gps1/raw",
+"type": "mavros_msgs/msg/GPSRAW"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/gpsstatus",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gpsstatus/gps1/rtk",
+"type": "mavros_msgs/msg/GPSRTK"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/gpsstatus",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gpsstatus/gps2/raw",
+"type": "mavros_msgs/msg/GPSRAW"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/gpsstatus",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/gpsstatus/gps2/rtk",
+"type": "mavros_msgs/msg/GPSRTK"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/hil",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/hil/actuator_controls",
+"type": "mavros_msgs/msg/HilActuatorControls"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/hil",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/hil/controls",
+"type": "mavros_msgs/msg/HilControls"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/hil",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/hil/gps",
+"type": "mavros_msgs/msg/HilGPS"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/hil",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/hil/imu_ned",
+"type": "mavros_msgs/msg/HilSensor"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/hil",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/hil/optical_flow",
+"type": "mavros_msgs/msg/OpticalFlowRad"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/hil",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/hil/rc_inputs",
+"type": "mavros_msgs/msg/RCIn"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/hil",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/hil/state",
+"type": "mavros_msgs/msg/HilStateQuaternion"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/home_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/home_position/home",
+"type": "mavros_msgs/msg/HomePosition"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/global_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/home_position/home",
+"type": "mavros_msgs/msg/HomePosition"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/home_position/home",
+"type": "mavros_msgs/msg/HomePosition"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/home_position/set",
+"type": "mavros_msgs/msg/HomePosition"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/home_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/home_position/set",
+"type": "mavros_msgs/msg/HomePosition"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/imu",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/imu/data",
+"type": "sensor_msgs/msg/Imu"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/imu",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/imu/data_raw",
+"type": "sensor_msgs/msg/Imu"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/imu",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/imu/diff_pressure",
+"type": "sensor_msgs/msg/FluidPressure"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/imu",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/imu/mag",
+"type": "sensor_msgs/msg/MagneticField"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/imu",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/imu/static_pressure",
+"type": "sensor_msgs/msg/FluidPressure"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/imu",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/imu/temperature_baro",
+"type": "sensor_msgs/msg/Temperature"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/imu",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/imu/temperature_imu",
+"type": "sensor_msgs/msg/Temperature"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/landing_target",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/landing_target/lt_marker",
+"type": "geometry_msgs/msg/Vector3Stamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/landing_target",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/landing_target/pose",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/landing_target",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/landing_target/pose_in",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/local_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/local_position/accel",
+"type": "geometry_msgs/msg/AccelWithCovarianceStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/local_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/local_position/odom",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/odometry_conversion/odometry_conversion",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/local_position/odom",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/local_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/local_position/pose",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/local_position/pose",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/local_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/local_position/pose_cov",
+"type": "geometry_msgs/msg/PoseWithCovarianceStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/local_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/local_position/velocity_body",
+"type": "geometry_msgs/msg/TwistStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/local_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/local_position/velocity_body_cov",
+"type": "geometry_msgs/msg/TwistWithCovarianceStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/local_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/local_position/velocity_local",
+"type": "geometry_msgs/msg/TwistStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/log_transfer",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/log_transfer/raw/log_data",
+"type": "mavros_msgs/msg/LogData"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/log_transfer",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/log_transfer/raw/log_entry",
+"type": "mavros_msgs/msg/LogEntry"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/mag_calibration",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/mag_calibration/report",
+"type": "mavros_msgs/msg/MagnetometerReporter"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/mag_calibration",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/mag_calibration/status",
+"type": "std_msgs/msg/UInt8"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/manual_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/manual_control/control",
+"type": "mavros_msgs/msg/ManualControl"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/manual_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/manual_control/send",
+"type": "mavros_msgs/msg/ManualControl"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/mission",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/mission/reached",
+"type": "mavros_msgs/msg/WaypointReached"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/mission",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/mission/waypoints",
+"type": "mavros_msgs/msg/WaypointList"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/mocap",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/mocap/pose",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/mocap",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/mocap/tf",
+"type": "geometry_msgs/msg/TransformStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/mount_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/mount_control/command",
+"type": "mavros_msgs/msg/MountControl"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/mount_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/mount_control/orientation",
+"type": "geometry_msgs/msg/Quaternion"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/mount_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/mount_control/status",
+"type": "geometry_msgs/msg/Vector3Stamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/nav_controller_output",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/nav_controller_output/output",
+"type": "mavros_msgs/msg/NavControllerOutput"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/obstacle",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/obstacle/send",
+"type": "sensor_msgs/msg/LaserScan"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/obstacle_distance_3d",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/obstacle_distance_3d/send",
+"type": "mavros_msgs/msg/ObstacleDistance3D"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/odometry",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/odometry/in",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/odometry",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/odometry/out",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/onboard_computer",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/onboard_computer/status",
+"type": "mavros_msgs/msg/OnboardComputerStatus"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/open_drone_id",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/open_drone_id/basic_id",
+"type": "mavros_msgs/msg/OpenDroneIDBasicID"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/open_drone_id",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/open_drone_id/operator_id",
+"type": "mavros_msgs/msg/OpenDroneIDOperatorID"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/open_drone_id",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/open_drone_id/self_id",
+"type": "mavros_msgs/msg/OpenDroneIDSelfID"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/open_drone_id",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/open_drone_id/system",
+"type": "mavros_msgs/msg/OpenDroneIDSystem"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/open_drone_id",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/open_drone_id/system_update",
+"type": "mavros_msgs/msg/OpenDroneIDSystemUpdate"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/optical_flow",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/optical_flow/ground_distance",
+"type": "sensor_msgs/msg/Range"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/optical_flow",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/optical_flow/raw/optical_flow",
+"type": "mavros_msgs/msg/OpticalFlow"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/optical_flow",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/optical_flow/raw/send",
+"type": "mavros_msgs/msg/OpticalFlow"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/param",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/param/event",
+"type": "mavros_msgs/msg/ParamEvent"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/play_tune",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/play_tune",
+"type": "mavros_msgs/msg/PlayTuneV2"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/px4flow",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/px4flow/ground_distance",
+"type": "sensor_msgs/msg/Range"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/px4flow",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/px4flow/raw/optical_flow_rad",
+"type": "mavros_msgs/msg/OpticalFlowRad"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/px4flow",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/px4flow/raw/send",
+"type": "mavros_msgs/msg/OpticalFlowRad"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/px4flow",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/px4flow/temperature",
+"type": "sensor_msgs/msg/Temperature"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/tdr_radio",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/radio_status",
+"type": "mavros_msgs/msg/RadioStatus"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/rallypoint",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/rallypoint/rallypoints",
+"type": "mavros_msgs/msg/WaypointList"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/rc",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/rc/in",
+"type": "mavros_msgs/msg/RCIn"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/rc",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/rc/out",
+"type": "mavros_msgs/msg/RCOut"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/rc",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/rc/override",
+"type": "mavros_msgs/msg/OverrideRCIn"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_accel",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_accel/accel",
+"type": "geometry_msgs/msg/Vector3Stamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_attitude",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/setpoint_attitude/cmd_vel",
+"type": "geometry_msgs/msg/TwistStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_attitude",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/setpoint_attitude/thrust",
+"type": "mavros_msgs/msg/Thrust"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/setpoint_position/global",
+"type": "geographic_msgs/msg/GeoPoseStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_position/global",
+"type": "geographic_msgs/msg/GeoPoseStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_position/global_to_local",
+"type": "geographic_msgs/msg/GeoPoseStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/setpoint_position/local",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_position",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_position/local",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/setpoint_raw/attitude",
+"type": "mavros_msgs/msg/AttitudeTarget"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_raw",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_raw/attitude",
+"type": "mavros_msgs/msg/AttitudeTarget"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_raw",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_raw/global",
+"type": "mavros_msgs/msg/GlobalPositionTarget"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/setpoint_raw/local",
+"type": "mavros_msgs/msg/PositionTarget"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_raw",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_raw/local",
+"type": "mavros_msgs/msg/PositionTarget"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/setpoint_raw",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_raw/target_attitude",
+"type": "mavros_msgs/msg/AttitudeTarget"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/setpoint_raw",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_raw/target_global",
+"type": "mavros_msgs/msg/GlobalPositionTarget"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/setpoint_raw",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_raw/target_local",
+"type": "mavros_msgs/msg/PositionTarget"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/setpoint_trajectory",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_trajectory/desired",
+"type": "nav_msgs/msg/Path"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_trajectory",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_trajectory/local",
+"type": "trajectory_msgs/msg/MultiDOFJointTrajectory"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_velocity",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_velocity/cmd_vel",
+"type": "geometry_msgs/msg/TwistStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/setpoint_velocity",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/setpoint_velocity/cmd_vel_unstamped",
+"type": "geometry_msgs/msg/Twist"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/sim_state",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/sim_state/acceleration",
+"type": "geometry_msgs/msg/Vector3Stamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/sim_state",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/sim_state/attitude",
+"type": "sensor_msgs/msg/Imu"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/sim_state",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/sim_state/global_position",
+"type": "sensor_msgs/msg/NavSatFix"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/sim_state",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/sim_state/velocity_body",
+"type": "geometry_msgs/msg/TwistStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/sim_state",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/sim_state/velocity_local",
+"type": "geometry_msgs/msg/TwistStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/sys",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/state",
+"type": "mavros_msgs/msg/State"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/state",
+"type": "mavros_msgs/msg/State"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/sys",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/status_event",
+"type": "mavros_msgs/msg/StatusEvent"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/sys",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/statustext/recv",
+"type": "mavros_msgs/msg/StatusText"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/sys",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/statustext/send",
+"type": "mavros_msgs/msg/StatusText"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/sys",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/sys_status",
+"type": "mavros_msgs/msg/SysStatus"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/actuator_control",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/target_actuator_control",
+"type": "mavros_msgs/msg/ActuatorControl"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/terrain",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/terrain/report",
+"type": "mavros_msgs/msg/TerrainReport"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/time",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/time_reference",
+"type": "sensor_msgs/msg/TimeReference"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/time",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/timesync_status",
+"type": "mavros_msgs/msg/TimesyncStatus"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/trajectory",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/trajectory/desired",
+"type": "mavros_msgs/msg/Trajectory"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/trajectory",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/trajectory/generated",
+"type": "mavros_msgs/msg/Trajectory"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/trajectory",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/trajectory/path",
+"type": "nav_msgs/msg/Path"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/tunnel",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/tunnel/in",
+"type": "mavros_msgs/msg/Tunnel"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/tunnel",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/tunnel/out",
+"type": "mavros_msgs/msg/Tunnel"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/vfr_hud",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/vfr_hud",
+"type": "mavros_msgs/msg/VfrHud"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/vision_pose",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/vision_pose/pose",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/vision_pose",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/vision_pose/pose_cov",
+"type": "geometry_msgs/msg/PoseWithCovarianceStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/vision_speed",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/vision_speed/speed_twist",
+"type": "geometry_msgs/msg/TwistStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/vision_speed",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/vision_speed/speed_twist_cov",
+"type": "geometry_msgs/msg/TwistWithCovarianceStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/vision_speed",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/mavros/vision_speed/speed_vector",
+"type": "geometry_msgs/msg/Vector3Stamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/wind",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/interface/mavros/wind_estimation",
+"type": "geometry_msgs/msg/TwistWithCovarianceStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/pose_command",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/rate_thrust_command",
+"type": "mav_msgs/msg/RateThrust"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/roll_pitch_yawrate_thrust_command",
+"type": "mav_msgs/msg/RollPitchYawrateThrust"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/torque_thrust_command",
+"type": "mav_msgs/msg/TorqueThrust"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/robot_interface",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/interface/velocity_command",
+"type": "geometry_msgs/msg/TwistStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/robot_state_publisher",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/joint_states",
+"type": "sensor_msgs/msg/JointState"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/macvo/odometry",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "pub",
+"node": "/robot_1/odometry_conversion/odometry_conversion",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/odometry_conversion/odometry",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/behavior/drone_safety_monitor/drone_safety_monitor",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/odometry_conversion/odometry",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/control/pid_controller",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/odometry_conversion/odometry",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/odom_modifier",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/odometry_conversion/odometry",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/random_walk_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/odometry_conversion/odometry",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/takeoff_landing_planner/takeoff_landing_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/odometry_conversion/odometry",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/odometry_conversion/odometry",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/trajectory_controller/fixed_trajectory_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/odometry_conversion/odometry",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/odometry_conversion/odometry",
+"type": "nav_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/perception/macvo/disparity",
+"type": "sensor_msgs/msg/Image"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/perception/macvo/point_cloud",
+"type": "sensor_msgs/msg/PointCloud"
+},
+{
+"dir": "pub",
+"node": "/robot_1/perception/stereo_image_proc/disparity_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/perception/stereo_image_proc/disparity",
+"type": "stereo_msgs/msg/DisparityImage"
+},
+{
+"dir": "sub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/perception/stereo_image_proc/disparity",
+"type": "stereo_msgs/msg/DisparityImage"
+},
+{
+"dir": "sub",
+"node": "/robot_1/perception/stereo_pointcloud",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/perception/stereo_image_proc/disparity",
+"type": "stereo_msgs/msg/DisparityImage"
+},
+{
+"dir": "pub",
+"node": "/robot_1/perception/stereo_pointcloud",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/perception/stereo_image_proc/point_cloud",
+"type": "sensor_msgs/msg/PointCloud2"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/perception/stereo_image_proc/point_cloud",
+"type": "sensor_msgs/msg/PointCloud2"
+},
+{
+"dir": "pub",
+"node": "/robot_1/random_walk_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/random_walk_node/goal_point_viz",
+"type": "visualization_msgs/msg/Marker"
+},
+{
+"dir": "pub",
+"node": "/robot_1/random_walk_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/random_walk_node/traj_viz",
+"type": "visualization_msgs/msg/Marker"
+},
+{
+"dir": "pub",
+"node": "/robot_1/robot_state_publisher",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/robot_description",
+"type": "std_msgs/msg/String"
+},
+{
+"dir": "sub",
+"node": "/robot_1/perception/stereo_image_proc/disparity_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/sensors/front_stereo/left/camera_info",
+"type": "sensor_msgs/msg/CameraInfo"
+},
+{
+"dir": "sub",
+"node": "/robot_1/perception/stereo_pointcloud",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/sensors/front_stereo/left/camera_info",
+"type": "sensor_msgs/msg/CameraInfo"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/sensors/front_stereo/left/camera_info",
+"type": "sensor_msgs/msg/CameraInfo"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/sensors/front_stereo/left/depth_ground_truth",
+"type": "sensor_msgs/msg/Image"
+},
+{
+"dir": "sub",
+"node": "/robot_1/perception/stereo_image_proc/disparity_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/sensors/front_stereo/left/image_rect",
+"type": "sensor_msgs/msg/Image"
+},
+{
+"dir": "sub",
+"node": "/robot_1/perception/stereo_pointcloud",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/sensors/front_stereo/left/image_rect",
+"type": "sensor_msgs/msg/Image"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/sensors/front_stereo/left/image_rect",
+"type": "sensor_msgs/msg/Image"
+},
+{
+"dir": "sub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/sensors/front_stereo/right/camera_info",
+"type": "sensor_msgs/msg/CameraInfo"
+},
+{
+"dir": "sub",
+"node": "/robot_1/perception/stereo_image_proc/disparity_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/sensors/front_stereo/right/camera_info",
+"type": "sensor_msgs/msg/CameraInfo"
+},
+{
+"dir": "sub",
+"node": "/robot_1/perception/stereo_pointcloud",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/sensors/front_stereo/right/camera_info",
+"type": "sensor_msgs/msg/CameraInfo"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/sensors/front_stereo/right/camera_info",
+"type": "sensor_msgs/msg/CameraInfo"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/sensors/front_stereo/right/depth_ground_truth",
+"type": "sensor_msgs/msg/Image"
+},
+{
+"dir": "sub",
+"node": "/robot_1/perception/stereo_image_proc/disparity_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/sensors/front_stereo/right/image_rect",
+"type": "sensor_msgs/msg/Image"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/sensors/front_stereo/right/image_rect",
+"type": "sensor_msgs/msg/Image"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/sensors/lidar/point_cloud",
+"type": "sensor_msgs/msg/PointCloud2"
+},
+{
+"dir": "pub",
+"node": "/robot_1/sensors/lidar_point_cloud_filter",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/sensors/ouster/point_cloud",
+"type": "sensor_msgs/msg/PointCloud2"
+},
+{
+"dir": "sub",
+"node": "/robot_1/vdb_mapping",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/sensors/ouster/point_cloud",
+"type": "sensor_msgs/msg/PointCloud2"
+},
+{
+"dir": "sub",
+"node": "/robot_1/sensors/lidar_point_cloud_filter",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/sensors/ouster/point_cloud_raw",
+"type": "sensor_msgs/msg/PointCloud2"
+},
+{
+"dir": "pub",
+"node": "/robot_1/takeoff_landing_planner/takeoff_landing_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/takeoff_landing_planner/is_airborne",
+"type": "std_msgs/msg/Bool"
+},
+{
+"dir": "sub",
+"node": "/robot_1/takeoff_landing_planner/takeoff_landing_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/takeoff_landing_planner/trajectory_completion_percentage",
+"type": "std_msgs/msg/Float32"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/closest_point",
+"type": "airstack_msgs/msg/Odometry"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/look_ahead",
+"type": "airstack_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/look_ahead",
+"type": "airstack_msgs/msg/Odometry"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/projected_drone_pose",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/odom_modifier",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/projected_drone_pose",
+"type": "geometry_msgs/msg/PoseStamped"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/tracking_error",
+"type": "std_msgs/msg/Float32"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/tracking_point",
+"type": "airstack_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/control/pid_controller",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/tracking_point",
+"type": "airstack_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/tracking_point",
+"type": "airstack_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/odom_modifier",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/tracking_point",
+"type": "airstack_msgs/msg/Odometry"
+},
+{
+"dir": "sub",
+"node": "/robot_1/takeoff_landing_planner/takeoff_landing_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/tracking_point",
+"type": "airstack_msgs/msg/Odometry"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/tracking_point_velocity_magnitude",
+"type": "std_msgs/msg/Float32"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/traj_drone_point",
+"type": "airstack_msgs/msg/Odometry"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/trajectory_completion_percentage",
+"type": "std_msgs/msg/Float32"
+},
+{
+"dir": "sub",
+"node": "/robot_1/trajectory_controller/fixed_trajectory_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/trajectory_completion_percentage",
+"type": "std_msgs/msg/Float32"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/trajectory_controller_debug_markers",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/trajectory_controller_debug_markers",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "pub",
+"node": "/robot_1/takeoff_landing_planner/takeoff_landing_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/trajectory_override",
+"type": "airstack_msgs/msg/TrajectoryXYZVYaw"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/fixed_trajectory_task",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/trajectory_override",
+"type": "airstack_msgs/msg/TrajectoryXYZVYaw"
+},
+{
+"dir": "sub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/trajectory_override",
+"type": "airstack_msgs/msg/TrajectoryXYZVYaw"
+},
+{
+"dir": "pub",
+"node": "/robot_1/droan/disparity_expander_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/trajectory_segment_to_add",
+"type": "airstack_msgs/msg/TrajectoryXYZVYaw"
+},
+{
+"dir": "sub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/trajectory_segment_to_add",
+"type": "airstack_msgs/msg/TrajectoryXYZVYaw"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/trajectory_time",
+"type": "std_msgs/msg/Float32"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/trajectory_vis",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/trajectory_vis",
+"type": "visualization_msgs/msg/MarkerArray"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/trajectory_controller/virtual_tracking_point",
+"type": "airstack_msgs/msg/Odometry"
+},
+{
+"dir": "pub",
+"node": "/robot_1/vdb_mapping",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/vdb_mapping/vdb_map_overwrites",
+"type": "vdb_mapping_interfaces/msg/UpdateGrid"
+},
+{
+"dir": "pub",
+"node": "/robot_1/vdb_mapping",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/vdb_mapping/vdb_map_pointcloud",
+"type": "sensor_msgs/msg/PointCloud2"
+},
+{
+"dir": "pub",
+"node": "/robot_1/vdb_mapping",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/vdb_mapping/vdb_map_sections",
+"type": "vdb_mapping_interfaces/msg/UpdateGrid"
+},
+{
+"dir": "pub",
+"node": "/robot_1/vdb_mapping",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/robot_1/vdb_mapping/vdb_map_updates",
+"type": "vdb_mapping_interfaces/msg/UpdateGrid"
+},
+{
+"dir": "pub",
+"node": "/robot_1/vdb_mapping",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/vdb_mapping/vdb_map_visualization",
+"type": "visualization_msgs/msg/Marker"
+},
+{
+"dir": "sub",
+"node": "/robot_1/random_walk_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/vdb_mapping/vdb_map_visualization",
+"type": "visualization_msgs/msg/Marker"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/robot_1/vdb_mapping/vdb_map_visualization",
+"type": "visualization_msgs/msg/Marker"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/mavros",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/tf",
+"type": "tf2_msgs/msg/TFMessage"
+},
+{
+"dir": "pub",
+"node": "/robot_1/odometry_conversion/odometry_conversion",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/tf",
+"type": "tf2_msgs/msg/TFMessage"
+},
+{
+"dir": "pub",
+"node": "/robot_1/robot_state_publisher",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/tf",
+"type": "tf2_msgs/msg/TFMessage"
+},
+{
+"dir": "pub",
+"node": "/robot_1/trajectory_controller/trajectory_control_node",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/tf",
+"type": "tf2_msgs/msg/TFMessage"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/odom_modifier",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/tf",
+"type": "tf2_msgs/msg/TFMessage"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/tf",
+"type": "tf2_msgs/msg/TFMessage"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/mavros",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/tf_static",
+"type": "tf2_msgs/msg/TFMessage"
+},
+{
+"dir": "pub",
+"node": "/robot_1/robot_state_publisher",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/tf_static",
+"type": "tf2_msgs/msg/TFMessage"
+},
+{
+"dir": "pub",
+"node": "/robot_1/world_to_map_broadcaster",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/tf_static",
+"type": "tf2_msgs/msg/TFMessage"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/odom_modifier",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/tf_static",
+"type": "tf2_msgs/msg/TFMessage"
+},
+{
+"dir": "sub",
+"node": "/robot_1/topic_keepalive",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"topic": "/tf_static",
+"type": "tf2_msgs/msg/TFMessage"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/mavros",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/uas2/mavlink_sink",
+"type": "mavros_msgs/msg/Mavlink"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/mavros_router",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/uas2/mavlink_sink",
+"type": "mavros_msgs/msg/Mavlink"
+},
+{
+"dir": "pub",
+"node": "/robot_1/interface/mavros/mavros_router",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/uas2/mavlink_source",
+"type": "mavros_msgs/msg/Mavlink"
+},
+{
+"dir": "sub",
+"node": "/robot_1/interface/mavros/mavros",
+"qos_profile": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"topic": "/uas2/mavlink_source",
+"type": "mavros_msgs/msg/Mavlink"
+}
+],
+"nodes": [
+"/action_relay_client",
+"/robot_1/Container",
+"/robot_1/behavior/drone_safety_monitor/drone_safety_monitor",
+"/robot_1/control/pid_controller",
+"/robot_1/droan/disparity_expander_node",
+"/robot_1/gossip_node",
+"/robot_1/interface/mavros/actuator_control",
+"/robot_1/interface/mavros/adsb",
+"/robot_1/interface/mavros/altitude",
+"/robot_1/interface/mavros/cam_imu_sync",
+"/robot_1/interface/mavros/camera",
+"/robot_1/interface/mavros/cellular_status",
+"/robot_1/interface/mavros/cmd",
+"/robot_1/interface/mavros/companion_process",
+"/robot_1/interface/mavros/debug_value",
+"/robot_1/interface/mavros/esc_status",
+"/robot_1/interface/mavros/esc_telemetry",
+"/robot_1/interface/mavros/fake_gps",
+"/robot_1/interface/mavros/ftp",
+"/robot_1/interface/mavros/geofence",
+"/robot_1/interface/mavros/gimbal_control",
+"/robot_1/interface/mavros/global_position",
+"/robot_1/interface/mavros/gps_input",
+"/robot_1/interface/mavros/gps_rtk",
+"/robot_1/interface/mavros/gpsstatus",
+"/robot_1/interface/mavros/guided_target",
+"/robot_1/interface/mavros/hil",
+"/robot_1/interface/mavros/home_position",
+"/robot_1/interface/mavros/imu",
+"/robot_1/interface/mavros/landing_target",
+"/robot_1/interface/mavros/local_position",
+"/robot_1/interface/mavros/log_transfer",
+"/robot_1/interface/mavros/mag_calibration",
+"/robot_1/interface/mavros/manual_control",
+"/robot_1/interface/mavros/mavros",
+"/robot_1/interface/mavros/mavros_node",
+"/robot_1/interface/mavros/mavros_router",
+"/robot_1/interface/mavros/mission",
+"/robot_1/interface/mavros/mocap",
+"/robot_1/interface/mavros/mount_control",
+"/robot_1/interface/mavros/nav_controller_output",
+"/robot_1/interface/mavros/obstacle",
+"/robot_1/interface/mavros/obstacle_distance_3d",
+"/robot_1/interface/mavros/odometry",
+"/robot_1/interface/mavros/onboard_computer",
+"/robot_1/interface/mavros/open_drone_id",
+"/robot_1/interface/mavros/optical_flow",
+"/robot_1/interface/mavros/param",
+"/robot_1/interface/mavros/play_tune",
+"/robot_1/interface/mavros/px4flow",
+"/robot_1/interface/mavros/rallypoint",
+"/robot_1/interface/mavros/rc",
+"/robot_1/interface/mavros/setpoint_accel",
+"/robot_1/interface/mavros/setpoint_attitude",
+"/robot_1/interface/mavros/setpoint_position",
+"/robot_1/interface/mavros/setpoint_raw",
+"/robot_1/interface/mavros/setpoint_trajectory",
+"/robot_1/interface/mavros/setpoint_velocity",
+"/robot_1/interface/mavros/sim_state",
+"/robot_1/interface/mavros/sys",
+"/robot_1/interface/mavros/tdr_radio",
+"/robot_1/interface/mavros/terrain",
+"/robot_1/interface/mavros/time",
+"/robot_1/interface/mavros/trajectory",
+"/robot_1/interface/mavros/tunnel",
+"/robot_1/interface/mavros/vfr_hud",
+"/robot_1/interface/mavros/vision_pose",
+"/robot_1/interface/mavros/vision_speed",
+"/robot_1/interface/mavros/wind",
+"/robot_1/interface/odom_modifier",
+"/robot_1/interface/robot_interface",
+"/robot_1/odometry_conversion/odometry_conversion",
+"/robot_1/perception/stereo_image_proc/disparity_node",
+"/robot_1/perception/stereo_pointcloud",
+"/robot_1/random_walk_node",
+"/robot_1/robot_state_publisher",
+"/robot_1/sensors/lidar_point_cloud_filter",
+"/robot_1/takeoff_landing_planner/takeoff_landing_task",
+"/robot_1/topic_keepalive",
+"/robot_1/trajectory_controller/fixed_trajectory_task",
+"/robot_1/trajectory_controller/trajectory_control_node",
+"/robot_1/vdb_mapping",
+"/robot_1/world_to_map_broadcaster"
+],
+"topics": {
+"/clock": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "rosgraph_msgs/msg/Clock"
+},
+"/diagnostics": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "diagnostic_msgs/msg/DiagnosticArray"
+},
+"/gossip/peers": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "coordination_msgs/msg/PeerProfile"
+},
+"/move_base_simple/goal": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/PoseStamped"
+},
+"/robot_1/behavior/drone_safety_monitor/command": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/String"
+},
+"/robot_1/behavior/drone_safety_monitor/state_estimate_timed_out": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/Bool"
+},
+"/robot_1/control/reset_integrators": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/Empty"
+},
+"/robot_1/control/vx_pid_info": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "pid_controller_msgs/msg/PIDInfo"
+},
+"/robot_1/control/vy_pid_info": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "pid_controller_msgs/msg/PIDInfo"
+},
+"/robot_1/control/vz_pid_info": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "pid_controller_msgs/msg/PIDInfo"
+},
+"/robot_1/control/x_pid_info": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "pid_controller_msgs/msg/PIDInfo"
+},
+"/robot_1/control/y_pid_info": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "pid_controller_msgs/msg/PIDInfo"
+},
+"/robot_1/control/z_pid_info": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "pid_controller_msgs/msg/PIDInfo"
+},
+"/robot_1/coordination/peer_registry": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "coordination_msgs/msg/PeerProfile"
+},
+"/robot_1/cross_track_error": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/PoseStamped"
+},
+"/robot_1/droan/background_expanded": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/Image"
+},
+"/robot_1/droan/clear_map": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/Empty"
+},
+"/robot_1/droan/disparity_graph": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/MarkerArray"
+},
+"/robot_1/droan/disparity_map_debug": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/MarkerArray"
+},
+"/robot_1/droan/expansion_cloud": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/PointCloud2"
+},
+"/robot_1/droan/expansion_poly": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/MarkerArray"
+},
+"/robot_1/droan/fg_bg_cloud": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/PointCloud2"
+},
+"/robot_1/droan/foreground_expanded": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/Image"
+},
+"/robot_1/droan/frustum": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/Marker"
+},
+"/robot_1/droan/graph_vis": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/MarkerArray"
+},
+"/robot_1/droan/local_planner_global_plan_vis": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/MarkerArray"
+},
+"/robot_1/droan/reset_stuck": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/Empty"
+},
+"/robot_1/droan/rewind_info": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/MarkerArray"
+},
+"/robot_1/droan/stuck": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/Bool"
+},
+"/robot_1/droan/traj_debug": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/MarkerArray"
+},
+"/robot_1/droan/trajectory_library_vis": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/MarkerArray"
+},
+"/robot_1/droan/virtual_obstacles": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/MarkerArray"
+},
+"/robot_1/global_plan": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "nav_msgs/msg/Path"
+},
+"/robot_1/interface/attitude_thrust_command": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mav_msgs/msg/AttitudeThrust"
+},
+"/robot_1/interface/cmd_attitude_thrust": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mav_msgs/msg/AttitudeThrust"
+},
+"/robot_1/interface/cmd_pose": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/PoseStamped"
+},
+"/robot_1/interface/cmd_rate_thrust": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mav_msgs/msg/RateThrust"
+},
+"/robot_1/interface/cmd_roll_pitch_yawrate_thrust": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mav_msgs/msg/RollPitchYawrateThrust"
+},
+"/robot_1/interface/cmd_torque_thrust": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mav_msgs/msg/TorqueThrust"
+},
+"/robot_1/interface/cmd_velocity": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/TwistStamped"
+},
+"/robot_1/interface/has_control": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/Bool"
+},
+"/robot_1/interface/is_armed": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/Bool"
+},
+"/robot_1/interface/mavros/actuator_control": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/ActuatorControl"
+},
+"/robot_1/interface/mavros/adsb/send": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/ADSBVehicle"
+},
+"/robot_1/interface/mavros/adsb/vehicle": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/ADSBVehicle"
+},
+"/robot_1/interface/mavros/altitude": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/Altitude"
+},
+"/robot_1/interface/mavros/battery": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/BatteryState"
+},
+"/robot_1/interface/mavros/cam_imu_sync/cam_imu_stamp": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/CamIMUStamp"
+},
+"/robot_1/interface/mavros/camera/image_captured": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/CameraImageCaptured"
+},
+"/robot_1/interface/mavros/cellular_status/status": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/CellularStatus"
+},
+"/robot_1/interface/mavros/companion_process/status": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/CompanionProcessStatus"
+},
+"/robot_1/interface/mavros/debug_value/debug": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/DebugValue"
+},
+"/robot_1/interface/mavros/debug_value/debug_float_array": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/DebugValue"
+},
+"/robot_1/interface/mavros/debug_value/debug_vector": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/DebugValue"
+},
+"/robot_1/interface/mavros/debug_value/named_value_float": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/DebugValue"
+},
+"/robot_1/interface/mavros/debug_value/named_value_int": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/DebugValue"
+},
+"/robot_1/interface/mavros/debug_value/send": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/DebugValue"
+},
+"/robot_1/interface/mavros/esc_status/info": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/ESCInfo"
+},
+"/robot_1/interface/mavros/esc_status/status": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/ESCStatus"
+},
+"/robot_1/interface/mavros/esc_telemetry/telemetry": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/ESCTelemetry"
+},
+"/robot_1/interface/mavros/estimator_status": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/EstimatorStatus"
+},
+"/robot_1/interface/mavros/extended_state": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/ExtendedState"
+},
+"/robot_1/interface/mavros/fake_gps/mocap/tf": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/TransformStamped"
+},
+"/robot_1/interface/mavros/geofence/fences": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/WaypointList"
+},
+"/robot_1/interface/mavros/gimbal_control/device/attitude_status": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/GimbalDeviceAttitudeStatus"
+},
+"/robot_1/interface/mavros/gimbal_control/device/info": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/GimbalDeviceInformation"
+},
+"/robot_1/interface/mavros/gimbal_control/device/set_attitude": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/GimbalDeviceSetAttitude"
+},
+"/robot_1/interface/mavros/gimbal_control/manager/info": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/GimbalManagerInformation"
+},
+"/robot_1/interface/mavros/gimbal_control/manager/set_attitude": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/GimbalManagerSetAttitude"
+},
+"/robot_1/interface/mavros/gimbal_control/manager/set_manual_control": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/GimbalManagerSetPitchyaw"
+},
+"/robot_1/interface/mavros/gimbal_control/manager/set_pitchyaw": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/GimbalManagerSetPitchyaw"
+},
+"/robot_1/interface/mavros/gimbal_control/manager/status": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/GimbalManagerStatus"
+},
+"/robot_1/interface/mavros/global_position/compass_hdg": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "std_msgs/msg/Float64"
+},
+"/robot_1/interface/mavros/global_position/global": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/NavSatFix"
+},
+"/robot_1/interface/mavros/global_position/gp_lp_offset": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/PoseStamped"
+},
+"/robot_1/interface/mavros/global_position/gp_origin": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geographic_msgs/msg/GeoPointStamped"
+},
+"/robot_1/interface/mavros/global_position/local": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "nav_msgs/msg/Odometry"
+},
+"/robot_1/interface/mavros/global_position/raw/fix": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/NavSatFix"
+},
+"/robot_1/interface/mavros/global_position/raw/gps_vel": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/TwistStamped"
+},
+"/robot_1/interface/mavros/global_position/raw/satellites": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "std_msgs/msg/UInt32"
+},
+"/robot_1/interface/mavros/global_position/rel_alt": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "std_msgs/msg/Float64"
+},
+"/robot_1/interface/mavros/global_position/set_gp_origin": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geographic_msgs/msg/GeoPointStamped"
+},
+"/robot_1/interface/mavros/gps_input/gps_input": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/GPSINPUT"
+},
+"/robot_1/interface/mavros/gps_rtk/rtk_baseline": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/RTKBaseline"
+},
+"/robot_1/interface/mavros/gps_rtk/send_rtcm": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/RTCM"
+},
+"/robot_1/interface/mavros/gpsstatus/gps1/raw": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/GPSRAW"
+},
+"/robot_1/interface/mavros/gpsstatus/gps1/rtk": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/GPSRTK"
+},
+"/robot_1/interface/mavros/gpsstatus/gps2/raw": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/GPSRAW"
+},
+"/robot_1/interface/mavros/gpsstatus/gps2/rtk": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/GPSRTK"
+},
+"/robot_1/interface/mavros/hil/actuator_controls": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/HilActuatorControls"
+},
+"/robot_1/interface/mavros/hil/controls": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/HilControls"
+},
+"/robot_1/interface/mavros/hil/gps": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/HilGPS"
+},
+"/robot_1/interface/mavros/hil/imu_ned": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/HilSensor"
+},
+"/robot_1/interface/mavros/hil/optical_flow": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/OpticalFlowRad"
+},
+"/robot_1/interface/mavros/hil/rc_inputs": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/RCIn"
+},
+"/robot_1/interface/mavros/hil/state": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/HilStateQuaternion"
+},
+"/robot_1/interface/mavros/home_position/home": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/HomePosition"
+},
+"/robot_1/interface/mavros/home_position/set": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/HomePosition"
+},
+"/robot_1/interface/mavros/imu/data": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/Imu"
+},
+"/robot_1/interface/mavros/imu/data_raw": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/Imu"
+},
+"/robot_1/interface/mavros/imu/diff_pressure": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/FluidPressure"
+},
+"/robot_1/interface/mavros/imu/mag": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/MagneticField"
+},
+"/robot_1/interface/mavros/imu/static_pressure": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/FluidPressure"
+},
+"/robot_1/interface/mavros/imu/temperature_baro": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/Temperature"
+},
+"/robot_1/interface/mavros/imu/temperature_imu": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/Temperature"
+},
+"/robot_1/interface/mavros/landing_target/lt_marker": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/Vector3Stamped"
+},
+"/robot_1/interface/mavros/landing_target/pose": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/PoseStamped"
+},
+"/robot_1/interface/mavros/landing_target/pose_in": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/PoseStamped"
+},
+"/robot_1/interface/mavros/local_position/accel": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/AccelWithCovarianceStamped"
+},
+"/robot_1/interface/mavros/local_position/odom": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "nav_msgs/msg/Odometry"
+},
+"/robot_1/interface/mavros/local_position/pose": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/PoseStamped"
+},
+"/robot_1/interface/mavros/local_position/pose_cov": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/PoseWithCovarianceStamped"
+},
+"/robot_1/interface/mavros/local_position/velocity_body": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/TwistStamped"
+},
+"/robot_1/interface/mavros/local_position/velocity_body_cov": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/TwistWithCovarianceStamped"
+},
+"/robot_1/interface/mavros/local_position/velocity_local": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/TwistStamped"
+},
+"/robot_1/interface/mavros/log_transfer/raw/log_data": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/LogData"
+},
+"/robot_1/interface/mavros/log_transfer/raw/log_entry": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/LogEntry"
+},
+"/robot_1/interface/mavros/mag_calibration/report": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/MagnetometerReporter"
+},
+"/robot_1/interface/mavros/mag_calibration/status": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/UInt8"
+},
+"/robot_1/interface/mavros/manual_control/control": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/ManualControl"
+},
+"/robot_1/interface/mavros/manual_control/send": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/ManualControl"
+},
+"/robot_1/interface/mavros/mission/reached": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/WaypointReached"
+},
+"/robot_1/interface/mavros/mission/waypoints": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/WaypointList"
+},
+"/robot_1/interface/mavros/mocap/pose": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/PoseStamped"
+},
+"/robot_1/interface/mavros/mocap/tf": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/TransformStamped"
+},
+"/robot_1/interface/mavros/mount_control/command": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/MountControl"
+},
+"/robot_1/interface/mavros/mount_control/orientation": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/Quaternion"
+},
+"/robot_1/interface/mavros/mount_control/status": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/Vector3Stamped"
+},
+"/robot_1/interface/mavros/nav_controller_output/output": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/NavControllerOutput"
+},
+"/robot_1/interface/mavros/obstacle/send": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/LaserScan"
+},
+"/robot_1/interface/mavros/obstacle_distance_3d/send": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/ObstacleDistance3D"
+},
+"/robot_1/interface/mavros/odometry/in": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "nav_msgs/msg/Odometry"
+},
+"/robot_1/interface/mavros/odometry/out": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "nav_msgs/msg/Odometry"
+},
+"/robot_1/interface/mavros/onboard_computer/status": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/OnboardComputerStatus"
+},
+"/robot_1/interface/mavros/open_drone_id/basic_id": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/OpenDroneIDBasicID"
+},
+"/robot_1/interface/mavros/open_drone_id/operator_id": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/OpenDroneIDOperatorID"
+},
+"/robot_1/interface/mavros/open_drone_id/self_id": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/OpenDroneIDSelfID"
+},
+"/robot_1/interface/mavros/open_drone_id/system": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/OpenDroneIDSystem"
+},
+"/robot_1/interface/mavros/open_drone_id/system_update": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/OpenDroneIDSystemUpdate"
+},
+"/robot_1/interface/mavros/optical_flow/ground_distance": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/Range"
+},
+"/robot_1/interface/mavros/optical_flow/raw/optical_flow": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/OpticalFlow"
+},
+"/robot_1/interface/mavros/optical_flow/raw/send": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/OpticalFlow"
+},
+"/robot_1/interface/mavros/param/event": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/ParamEvent"
+},
+"/robot_1/interface/mavros/play_tune": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/PlayTuneV2"
+},
+"/robot_1/interface/mavros/px4flow/ground_distance": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/Range"
+},
+"/robot_1/interface/mavros/px4flow/raw/optical_flow_rad": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/OpticalFlowRad"
+},
+"/robot_1/interface/mavros/px4flow/raw/send": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/OpticalFlowRad"
+},
+"/robot_1/interface/mavros/px4flow/temperature": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/Temperature"
+},
+"/robot_1/interface/mavros/radio_status": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/RadioStatus"
+},
+"/robot_1/interface/mavros/rallypoint/rallypoints": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/WaypointList"
+},
+"/robot_1/interface/mavros/rc/in": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/RCIn"
+},
+"/robot_1/interface/mavros/rc/out": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/RCOut"
+},
+"/robot_1/interface/mavros/rc/override": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/OverrideRCIn"
+},
+"/robot_1/interface/mavros/setpoint_accel/accel": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/Vector3Stamped"
+},
+"/robot_1/interface/mavros/setpoint_attitude/cmd_vel": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/TwistStamped"
+},
+"/robot_1/interface/mavros/setpoint_attitude/thrust": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/Thrust"
+},
+"/robot_1/interface/mavros/setpoint_position/global": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geographic_msgs/msg/GeoPoseStamped"
+},
+"/robot_1/interface/mavros/setpoint_position/global_to_local": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geographic_msgs/msg/GeoPoseStamped"
+},
+"/robot_1/interface/mavros/setpoint_position/local": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/PoseStamped"
+},
+"/robot_1/interface/mavros/setpoint_raw/attitude": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/AttitudeTarget"
+},
+"/robot_1/interface/mavros/setpoint_raw/global": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/GlobalPositionTarget"
+},
+"/robot_1/interface/mavros/setpoint_raw/local": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/PositionTarget"
+},
+"/robot_1/interface/mavros/setpoint_raw/target_attitude": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/AttitudeTarget"
+},
+"/robot_1/interface/mavros/setpoint_raw/target_global": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/GlobalPositionTarget"
+},
+"/robot_1/interface/mavros/setpoint_raw/target_local": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/PositionTarget"
+},
+"/robot_1/interface/mavros/setpoint_trajectory/desired": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "nav_msgs/msg/Path"
+},
+"/robot_1/interface/mavros/setpoint_trajectory/local": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "trajectory_msgs/msg/MultiDOFJointTrajectory"
+},
+"/robot_1/interface/mavros/setpoint_velocity/cmd_vel": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/TwistStamped"
+},
+"/robot_1/interface/mavros/setpoint_velocity/cmd_vel_unstamped": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/Twist"
+},
+"/robot_1/interface/mavros/sim_state/acceleration": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/Vector3Stamped"
+},
+"/robot_1/interface/mavros/sim_state/attitude": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/Imu"
+},
+"/robot_1/interface/mavros/sim_state/global_position": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/NavSatFix"
+},
+"/robot_1/interface/mavros/sim_state/velocity_body": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/TwistStamped"
+},
+"/robot_1/interface/mavros/sim_state/velocity_local": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/TwistStamped"
+},
+"/robot_1/interface/mavros/state": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/State"
+},
+"/robot_1/interface/mavros/status_event": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/StatusEvent"
+},
+"/robot_1/interface/mavros/statustext/recv": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/StatusText"
+},
+"/robot_1/interface/mavros/statustext/send": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/StatusText"
+},
+"/robot_1/interface/mavros/sys_status": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/SysStatus"
+},
+"/robot_1/interface/mavros/target_actuator_control": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/ActuatorControl"
+},
+"/robot_1/interface/mavros/terrain/report": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/TerrainReport"
+},
+"/robot_1/interface/mavros/time_reference": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/TimeReference"
+},
+"/robot_1/interface/mavros/timesync_status": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/TimesyncStatus"
+},
+"/robot_1/interface/mavros/trajectory/desired": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/Trajectory"
+},
+"/robot_1/interface/mavros/trajectory/generated": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/Trajectory"
+},
+"/robot_1/interface/mavros/trajectory/path": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "nav_msgs/msg/Path"
+},
+"/robot_1/interface/mavros/tunnel/in": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/Tunnel"
+},
+"/robot_1/interface/mavros/tunnel/out": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/Tunnel"
+},
+"/robot_1/interface/mavros/vfr_hud": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mavros_msgs/msg/VfrHud"
+},
+"/robot_1/interface/mavros/vision_pose/pose": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/PoseStamped"
+},
+"/robot_1/interface/mavros/vision_pose/pose_cov": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/PoseWithCovarianceStamped"
+},
+"/robot_1/interface/mavros/vision_speed/speed_twist": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/TwistStamped"
+},
+"/robot_1/interface/mavros/vision_speed/speed_twist_cov": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/TwistWithCovarianceStamped"
+},
+"/robot_1/interface/mavros/vision_speed/speed_vector": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/Vector3Stamped"
+},
+"/robot_1/interface/mavros/wind_estimation": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "geometry_msgs/msg/TwistWithCovarianceStamped"
+},
+"/robot_1/interface/pose_command": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/PoseStamped"
+},
+"/robot_1/interface/rate_thrust_command": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mav_msgs/msg/RateThrust"
+},
+"/robot_1/interface/roll_pitch_yawrate_thrust_command": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mav_msgs/msg/RollPitchYawrateThrust"
+},
+"/robot_1/interface/torque_thrust_command": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "mav_msgs/msg/TorqueThrust"
+},
+"/robot_1/interface/velocity_command": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/TwistStamped"
+},
+"/robot_1/joint_states": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/JointState"
+},
+"/robot_1/macvo/odometry": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "nav_msgs/msg/Odometry"
+},
+"/robot_1/odometry_conversion/odometry": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "nav_msgs/msg/Odometry"
+},
+"/robot_1/perception/macvo/disparity": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/Image"
+},
+"/robot_1/perception/macvo/point_cloud": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/PointCloud"
+},
+"/robot_1/perception/stereo_image_proc/disparity": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "stereo_msgs/msg/DisparityImage"
+},
+"/robot_1/perception/stereo_image_proc/point_cloud": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/PointCloud2"
+},
+"/robot_1/random_walk_node/goal_point_viz": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/Marker"
+},
+"/robot_1/random_walk_node/traj_viz": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/Marker"
+},
+"/robot_1/robot_description": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/String"
+},
+"/robot_1/sensors/front_stereo/left/camera_info": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/CameraInfo"
+},
+"/robot_1/sensors/front_stereo/left/depth_ground_truth": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/Image"
+},
+"/robot_1/sensors/front_stereo/left/image_rect": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/Image"
+},
+"/robot_1/sensors/front_stereo/right/camera_info": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/CameraInfo"
+},
+"/robot_1/sensors/front_stereo/right/depth_ground_truth": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/Image"
+},
+"/robot_1/sensors/front_stereo/right/image_rect": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/Image"
+},
+"/robot_1/sensors/lidar/point_cloud": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "sensor_msgs/msg/PointCloud2"
+},
+"/robot_1/sensors/ouster/point_cloud": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/PointCloud2"
+},
+"/robot_1/sensors/ouster/point_cloud_raw": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/PointCloud2"
+},
+"/robot_1/takeoff_landing_planner/is_airborne": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/Bool"
+},
+"/robot_1/takeoff_landing_planner/trajectory_completion_percentage": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/Float32"
+},
+"/robot_1/trajectory_controller/closest_point": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "airstack_msgs/msg/Odometry"
+},
+"/robot_1/trajectory_controller/look_ahead": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "airstack_msgs/msg/Odometry"
+},
+"/robot_1/trajectory_controller/projected_drone_pose": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "geometry_msgs/msg/PoseStamped"
+},
+"/robot_1/trajectory_controller/tracking_error": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/Float32"
+},
+"/robot_1/trajectory_controller/tracking_point": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "airstack_msgs/msg/Odometry"
+},
+"/robot_1/trajectory_controller/tracking_point_velocity_magnitude": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/Float32"
+},
+"/robot_1/trajectory_controller/traj_drone_point": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "airstack_msgs/msg/Odometry"
+},
+"/robot_1/trajectory_controller/trajectory_completion_percentage": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/Float32"
+},
+"/robot_1/trajectory_controller/trajectory_controller_debug_markers": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/MarkerArray"
+},
+"/robot_1/trajectory_controller/trajectory_override": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "airstack_msgs/msg/TrajectoryXYZVYaw"
+},
+"/robot_1/trajectory_controller/trajectory_segment_to_add": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "airstack_msgs/msg/TrajectoryXYZVYaw"
+},
+"/robot_1/trajectory_controller/trajectory_time": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "std_msgs/msg/Float32"
+},
+"/robot_1/trajectory_controller/trajectory_vis": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/MarkerArray"
+},
+"/robot_1/trajectory_controller/virtual_tracking_point": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "airstack_msgs/msg/Odometry"
+},
+"/robot_1/vdb_mapping/vdb_map_overwrites": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "vdb_mapping_interfaces/msg/UpdateGrid"
+},
+"/robot_1/vdb_mapping/vdb_map_pointcloud": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "sensor_msgs/msg/PointCloud2"
+},
+"/robot_1/vdb_mapping/vdb_map_sections": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "vdb_mapping_interfaces/msg/UpdateGrid"
+},
+"/robot_1/vdb_mapping/vdb_map_updates": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "vdb_mapping_interfaces/msg/UpdateGrid"
+},
+"/robot_1/vdb_mapping/vdb_map_visualization": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "visualization_msgs/msg/Marker"
+},
+"/tf": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "tf2_msgs/msg/TFMessage"
+},
+"/tf_static": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "TRANSIENT_LOCAL",
+"history": "UNKNOWN",
+"reliability": "RELIABLE"
+},
+"type": "tf2_msgs/msg/TFMessage"
+},
+"/uas2/mavlink_sink": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/Mavlink"
+},
+"/uas2/mavlink_source": {
+"qos": {
+"depth": "UNKNOWN",
+"durability": "VOLATILE",
+"history": "UNKNOWN",
+"reliability": "BEST_EFFORT"
+},
+"type": "mavros_msgs/msg/Mavlink"
+}
+},
+"version": 1
+}
+wiring-graph-v1 -->

--- a/tests/harness/collection.py
+++ b/tests/harness/collection.py
@@ -25,6 +25,7 @@ _MODULE_ORDER = [
     # build, so they run after build_packages and before the sim tiers.
     "__integration__",
     "system.test_liveliness",
+    "system.test_wiring_snapshot",
     "system.test_sensors",
     "system.test_takeoff_hover_land",
     "system.test_fixed_trajectory",

--- a/tests/harness/run_meta.py
+++ b/tests/harness/run_meta.py
@@ -14,6 +14,7 @@ RUN_META_FILENAME = "run_meta.json"
 
 SIMULATION_MODULES = (
     "system.test_liveliness.",
+    "system.test_wiring_snapshot.",
     "system.test_sensors.",
     "system.test_takeoff_hover_land.",
     "system.test_fixed_trajectory.",

--- a/tests/meta/test_module_manifest_contract.py
+++ b/tests/meta/test_module_manifest_contract.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026 Carnegie Mellon University
+# MIT License - see LICENSE in the repository root for full text.
+"""Contract tests for the module manifest schema + validator (RFC #379 §2, Phase P1).
+
+``tools/validate_module.py`` interprets ``common/module_schema/module.schema.json``
+with a generic walker — these tests pin the contract both sides must keep: the
+required fields and their shapes, the custom format hooks (semver ranges, path
+safety), dir-mode cross-file checks, and the stable JSON verdict emitted for
+scripts. The valid fixture module lives at ``tests/fixtures/modules/hello_module``.
+
+The validator is exercised both through its Python API (fast, most cases) and as a
+subprocess (the CLI contract: verdict on stdout, exit code).
+"""
+import copy
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+from harness.discovery import repo_path
+
+pytestmark = pytest.mark.unit
+
+VALIDATOR = repo_path("tools", "validate_module.py")
+SCHEMA = repo_path("common", "module_schema", "module.schema.json")
+FIXTURE = repo_path("tests", "fixtures", "modules", "hello_module")
+
+
+def _load_validator():
+    spec = importlib.util.spec_from_file_location("airstack_validate_module", VALIDATOR)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def vm():
+    return _load_validator()
+
+
+@pytest.fixture()
+def manifest():
+    """A fresh copy of the valid fixture manifest, ready to mutate."""
+    with (FIXTURE / "module.yaml").open(encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _validate(vm, tmp_path, data, as_dir=True):
+    """Write a manifest into tmp_path and validate; return (verdict, warnings)."""
+    (tmp_path / "module.yaml").write_text(yaml.safe_dump(data), encoding="utf-8")
+    target = tmp_path if as_dir else tmp_path / "module.yaml"
+    return vm.validate_module(target)
+
+
+def _error_paths(verdict):
+    return {e["path"] for e in verdict["errors"]}
+
+
+# ── the valid fixture passes ───────────────────────────────────────────────
+
+def test_valid_fixture_passes_via_import(vm):
+    verdict, warnings = vm.validate_module(FIXTURE)
+    assert verdict["valid"] is True, verdict["errors"]
+    assert verdict["errors"] == []
+    assert warnings == []  # tests.packages: [hello_module] matches a real directory
+
+
+def test_valid_fixture_passes_via_subprocess():
+    assert os.access(VALIDATOR, os.X_OK), "tools/validate_module.py must be executable"
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR), str(FIXTURE)],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    verdict = json.loads(result.stdout)
+    assert verdict == {"valid": True, "errors": []}
+
+
+# ── schema violations ──────────────────────────────────────────────────────
+
+def test_missing_maintainer_fails_naming_the_path(vm, tmp_path, manifest):
+    del manifest["maintainer"]
+    verdict, _ = _validate(vm, tmp_path, manifest)
+    assert verdict["valid"] is False
+    assert "maintainer" in _error_paths(verdict)
+
+
+def test_bad_type_enum_fails(vm, tmp_path, manifest):
+    manifest["type"] = "launch_bundle"
+    verdict, _ = _validate(vm, tmp_path, manifest)
+    assert verdict["valid"] is False
+    assert "type" in _error_paths(verdict)
+
+
+@pytest.mark.parametrize("bad_range", ["main", "latest", "0.19"])
+def test_malformed_airstack_compat_fails(vm, tmp_path, manifest, bad_range):
+    manifest["airstack_compat"] = bad_range
+    verdict, _ = _validate(vm, tmp_path, manifest)
+    assert verdict["valid"] is False
+    assert "airstack_compat" in _error_paths(verdict)
+
+
+@pytest.mark.parametrize(
+    "good_range",
+    [">=0.19.0 <0.21.0", ">=0.19.0-alpha.18 <0.20.0", "0.20.0", "^0.19.0"],
+)
+def test_wellformed_airstack_compat_passes(vm, tmp_path, manifest, good_range):
+    manifest["airstack_compat"] = good_range
+    verdict, _ = _validate(vm, tmp_path, manifest)
+    assert verdict["valid"] is True, verdict["errors"]
+
+
+def test_asset_with_http_url_fails(vm, tmp_path, manifest):
+    manifest["assets"] = [{
+        "url": "http://example.com/asset.tar",
+        "sha256": "0" * 64,
+        "dest": "assets/asset.tar",
+    }]
+    verdict, _ = _validate(vm, tmp_path, manifest)
+    assert verdict["valid"] is False
+    assert "assets[0].url" in _error_paths(verdict)
+
+
+def test_asset_dest_with_traversal_fails(vm, tmp_path, manifest):
+    manifest["assets"] = [{
+        "url": "https://example.com/asset.tar",
+        "sha256": "0" * 64,
+        "dest": "../outside/asset.tar",
+    }]
+    verdict, _ = _validate(vm, tmp_path, manifest)
+    assert verdict["valid"] is False
+    assert "assets[0].dest" in _error_paths(verdict)
+
+
+def test_unknown_top_level_key_fails(vm, tmp_path, manifest):
+    manifest["slot"] = "local_planner"  # wiring metadata is deliberately absent
+    verdict, _ = _validate(vm, tmp_path, manifest)
+    assert verdict["valid"] is False
+    assert "slot" in _error_paths(verdict)
+
+
+def test_unknown_mark_fails(vm, tmp_path, manifest):
+    manifest["tests"] = {"packages": [], "marks": ["hover_forever"]}
+    verdict, _ = _validate(vm, tmp_path, manifest)
+    assert verdict["valid"] is False
+    assert "tests.marks[0]" in _error_paths(verdict)
+
+
+def test_empty_targets_fails(vm, tmp_path, manifest):
+    manifest["targets"] = []
+    verdict, _ = _validate(vm, tmp_path, manifest)
+    assert verdict["valid"] is False
+    assert "targets" in _error_paths(verdict)
+
+
+# ── dir-mode cross-file checks ─────────────────────────────────────────────
+
+def test_dockerfile_pointing_at_nonexistent_file_fails_in_dir_mode(vm, tmp_path, manifest):
+    manifest["dockerfile"] = "Dockerfile.module"  # declared but never created
+    verdict, _ = _validate(vm, tmp_path, manifest, as_dir=True)
+    assert verdict["valid"] is False
+    assert "dockerfile" in _error_paths(verdict)
+
+
+def test_dockerfile_declared_and_present_passes(vm, tmp_path, manifest):
+    manifest["dockerfile"] = "Dockerfile.module"
+    (tmp_path / "Dockerfile.module").write_text("ARG BASE_IMAGE\nFROM ${BASE_IMAGE}\n")
+    verdict, _ = _validate(vm, tmp_path, manifest, as_dir=True)
+    assert verdict["valid"] is True, verdict["errors"]
+
+
+def test_file_mode_skips_cross_file_checks(vm, tmp_path, manifest):
+    """Given a bare module.yaml (not a dir), declared paths are not probed."""
+    manifest["dockerfile"] = "Dockerfile.module"
+    verdict, _ = _validate(vm, tmp_path, manifest, as_dir=False)
+    assert verdict["valid"] is True, verdict["errors"]
+
+
+def test_missing_tests_package_dir_warns_but_stays_valid(vm, tmp_path, manifest):
+    manifest["tests"] = {"packages": ["no_such_package"], "marks": []}
+    verdict, warnings = _validate(vm, tmp_path, manifest, as_dir=True)
+    assert verdict["valid"] is True, verdict["errors"]
+    assert warnings and "no_such_package" in warnings[0]
+
+
+# ── verdict shape ──────────────────────────────────────────────────────────
+
+def test_json_verdict_shape_is_stable(vm, tmp_path, manifest):
+    """Scripts parse the stdout verdict: exactly {valid, errors:[{path,message}]}."""
+    broken = copy.deepcopy(manifest)
+    del broken["maintainer"]
+    for data in (manifest, broken):
+        verdict, _ = _validate(vm, tmp_path, data)
+        assert set(verdict.keys()) == {"valid", "errors"}
+        assert isinstance(verdict["valid"], bool)
+        assert isinstance(verdict["errors"], list)
+        for error in verdict["errors"]:
+            assert set(error.keys()) == {"path", "message"}
+
+
+def test_invalid_manifest_exits_1_via_subprocess(tmp_path, manifest):
+    del manifest["maintainer"]
+    (tmp_path / "module.yaml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR), str(tmp_path)],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 1
+    verdict = json.loads(result.stdout)
+    assert verdict["valid"] is False
+    assert "maintainer" in result.stderr  # human-readable error names the path
+
+
+def test_schema_keeps_to_the_interpreted_subset():
+    """The walker only interprets a fixed keyword subset — the schema must not
+    quietly grow keywords (oneOf, $ref, ...) the validator would silently ignore."""
+    allowed = {
+        "$schema", "title", "description", "default",
+        "type", "required", "properties", "enum", "pattern", "items",
+        "additionalProperties", "minLength", "minItems",
+        "x-airstack-format", "x-airstack-check-exists", "x-airstack-warn-missing-dir",
+    }
+
+    def keys(node):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                yield key
+                if key in ("properties",):
+                    for sub in value.values():
+                        yield from keys(sub)
+                elif key in ("items", "additionalProperties"):
+                    yield from keys(value)
+        return
+
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    unknown = set(keys(schema)) - allowed
+    assert not unknown, f"schema uses keywords the validator does not interpret: {unknown}"

--- a/tests/meta/test_wiring_snapshot_contract.py
+++ b/tests/meta/test_wiring_snapshot_contract.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2024 Carnegie Mellon University
+# MIT License - see LICENSE in the repository root for full text.
+"""Contract tests for the wiring-snapshot tool (RFC #379 §4.4).
+
+``tests/wiring_snapshot.py`` turns ``ros2 topic info --verbose`` output into a
+committed ``wiring.md`` and diffs snapshots for drift. These tests pin the
+contracts the system test and the golden files depend on: the Jazzy verbose
+parser, infra-noise normalization, deterministic mermaid rendering, the
+render→extract round trip, drift verdicts, and the CLI exit codes.
+"""
+import json
+
+import pytest
+
+import wiring_snapshot as ws  # noqa: E402 — pytest adds tests/ to sys.path
+
+pytestmark = pytest.mark.unit
+
+
+# Realistic ROS 2 Jazzy `ros2 topic info --verbose` output: one publisher and
+# one subscription, each with a full QoS block; GIDs and type hashes present
+# so the parser is proven to drop them.
+ODOM_INFO = """\
+Type: nav_msgs/msg/Odometry
+
+Publisher count: 1
+
+Node name: mavros
+Node namespace: /robot_1/interface/mavros
+Topic type: nav_msgs/msg/Odometry
+Topic type hash: RIHS01_9f3c1cb1c9e3d2b6c4a1f0e9d8c7b6a5f4e3d2c1b0a9f8e7d6c5b4a3f2e1d0
+Endpoint type: PUBLISHER
+GID: 01.0f.cc.d1.62.5c.9e.ac.01.00.00.00.00.00.15.03
+QoS profile:
+  Reliability: RELIABLE
+  History (Depth): KEEP_LAST (10)
+  Durability: VOLATILE
+  Lifespan: Infinite
+  Deadline: Infinite
+  Liveliness: AUTOMATIC
+  Liveliness lease duration: Infinite
+
+Subscription count: 1
+
+Node name: trajectory_control_node
+Node namespace: /robot_1/trajectory_controller
+Topic type: nav_msgs/msg/Odometry
+Topic type hash: RIHS01_9f3c1cb1c9e3d2b6c4a1f0e9d8c7b6a5f4e3d2c1b0a9f8e7d6c5b4a3f2e1d0
+Endpoint type: SUBSCRIPTION
+GID: 01.0f.cc.d1.62.5c.9e.ac.01.00.00.00.00.00.16.04
+QoS profile:
+  Reliability: BEST_EFFORT
+  History (Depth): UNKNOWN
+  Durability: VOLATILE
+  Lifespan: Infinite
+  Deadline: Infinite
+  Liveliness: AUTOMATIC
+  Liveliness lease duration: Infinite
+"""
+
+TF_INFO = """\
+Type: tf2_msgs/msg/TFMessage
+
+Publisher count: 1
+
+Node name: robot_state_publisher
+Node namespace: /robot_1
+Topic type: tf2_msgs/msg/TFMessage
+Endpoint type: PUBLISHER
+GID: 01.0f.cc.d1.62.5c.9e.ac.01.00.00.00.00.00.17.03
+QoS profile:
+  Reliability: RELIABLE
+  History (Depth): KEEP_LAST (100)
+  Durability: VOLATILE
+  Lifespan: Infinite
+  Deadline: Infinite
+  Liveliness: AUTOMATIC
+  Liveliness lease duration: Infinite
+
+Subscription count: 0
+"""
+
+ROSOUT_INFO = """\
+Type: rcl_interfaces/msg/Log
+
+Publisher count: 1
+
+Node name: mavros
+Node namespace: /robot_1/interface/mavros
+Topic type: rcl_interfaces/msg/Log
+Endpoint type: PUBLISHER
+GID: 01.0f.cc.d1.62.5c.9e.ac.01.00.00.00.00.00.18.03
+QoS profile:
+  Reliability: RELIABLE
+  History (Depth): KEEP_LAST (1000)
+  Durability: TRANSIENT_LOCAL
+  Lifespan: 10000000000 nanoseconds
+  Deadline: Infinite
+  Liveliness: AUTOMATIC
+  Liveliness lease duration: Infinite
+
+Subscription count: 0
+"""
+
+
+def _sample_graph():
+    """Assemble a graph the way the system test does, then normalize it."""
+    topics = {}
+    edges = []
+    for topic, text in (
+        ("/robot_1/odometry", ODOM_INFO),
+        ("/tf", TF_INFO),
+        ("/rosout", ROSOUT_INFO),
+    ):
+        entry, topic_edges = ws.parse_topic_info_verbose(topic, text)
+        topics[topic] = entry
+        edges.extend(topic_edges)
+    nodes = [
+        "/launch_ros_12345",
+        "/robot_1/interface/mavros/mavros",
+        "/robot_1/robot_state_publisher",
+        "/robot_1/trajectory_controller/trajectory_control_node",
+        "/robot_1/transform_listener_impl_55d0a1b2c3d4",
+    ]
+    return ws.normalize_graph(
+        {"version": 1, "nodes": nodes, "topics": topics, "edges": edges}
+    )
+
+
+def test_parser_extracts_endpoints_types_and_qos():
+    entry, edges = ws.parse_topic_info_verbose("/robot_1/odometry", ODOM_INFO)
+
+    assert entry["type"] == "nav_msgs/msg/Odometry"
+    # Topic-level QoS comes from the first publisher.
+    assert entry["qos"] == {"reliability": "RELIABLE", "durability": "VOLATILE",
+                            "history": "KEEP_LAST", "depth": "10"}
+
+    assert len(edges) == 2
+    pub, sub = edges
+    assert pub["dir"] == "pub"
+    assert pub["node"] == "/robot_1/interface/mavros/mavros"
+    assert pub["type"] == "nav_msgs/msg/Odometry"
+    assert sub["dir"] == "sub"
+    assert sub["node"] == "/robot_1/trajectory_controller/trajectory_control_node"
+    assert sub["qos_profile"] == {"reliability": "BEST_EFFORT",
+                                  "durability": "VOLATILE",
+                                  "history": "UNKNOWN", "depth": "UNKNOWN"}
+    # GIDs are non-deterministic and must not leak into the model.
+    assert "GID" not in json.dumps(edges)
+
+
+def test_normalize_excludes_infra_but_keeps_tf():
+    graph = _sample_graph()
+
+    assert "/rosout" not in graph["topics"]
+    assert not any(e["topic"] == "/rosout" for e in graph["edges"])
+    # /tf and /tf_static are wiring — they stay.
+    assert "/tf" in graph["topics"]
+    # launch/CLI helper nodes (pid/hex-suffixed) are excluded.
+    assert "/launch_ros_12345" not in graph["nodes"]
+    assert "/robot_1/transform_listener_impl_55d0a1b2c3d4" not in graph["nodes"]
+    assert "/robot_1/robot_state_publisher" in graph["nodes"]
+    # Normalization is idempotent (diff_graphs re-normalizes both sides).
+    assert ws.normalize_graph(graph) == graph
+
+
+def test_mermaid_render_is_deterministic_and_grouped():
+    graph = _sample_graph()
+    first = ws.render_mermaid(graph)
+    second = ws.render_mermaid(graph)
+
+    assert first == second
+    assert first.startswith("graph LR")
+    # Nodes group by the namespace segment after the robot namespace.
+    assert 'subgraph g0["interface"]' in first
+    # pub×sub edge with topic + shortened type as the label.
+    assert '-->|"/robot_1/odometry<br/>Odometry"|' in first
+    # /tf has a publisher but no subscriber → dangling annotation node.
+    assert "(no subscribers)" in first
+
+
+def test_render_extract_round_trips_graph_exactly():
+    graph = _sample_graph()
+    meta = {"stack": "full_default", "generated-by": "contract-test",
+            "date": "2026-08-20 00:00:00", "sim": "isaacsim",
+            "num_robots": 1, "source-sha": "deadbee"}
+    text = ws.render_wiring_md(graph, meta)
+
+    assert text.startswith("# Wiring snapshot: full_default")
+    assert "- **sim**: isaacsim" in text
+    assert "```mermaid" in text
+    assert ws.extract_graph_from_md(text) == graph
+
+
+def test_diff_identical_graphs():
+    graph = _sample_graph()
+    verdict = ws.diff_graphs(graph, graph)
+
+    assert verdict["identical"] is True
+    assert verdict["missing_edges"] == []
+    assert verdict["extra_edges"] == []
+    assert verdict["qos_mismatches"] == []
+    assert verdict["type_mismatches"] == []
+
+
+def test_diff_reports_removed_edge_as_missing():
+    expected = _sample_graph()
+    observed = json.loads(json.dumps(expected))
+    removed = next(e for e in observed["edges"] if e["dir"] == "sub")
+    observed["edges"].remove(removed)
+
+    verdict = ws.diff_graphs(expected, observed)
+
+    assert verdict["identical"] is False
+    assert verdict["missing_edges"] == [
+        f"sub:{removed['node']}:{removed['topic']}"
+    ]
+    assert verdict["extra_edges"] == []
+
+
+def test_main_diff_exit_codes(tmp_path, capsys):
+    graph = _sample_graph()
+    expected_md = tmp_path / "wiring.md"
+    expected_md.write_text(ws.render_wiring_md(graph, {"stack": "full_default"}))
+
+    same = tmp_path / "observed_same.json"
+    same.write_text(json.dumps(graph))
+    rc = ws.main(["diff", "--expected", str(expected_md),
+                  "--observed", str(same)])
+    verdict = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert verdict["identical"] is True
+
+    drifted_graph = json.loads(json.dumps(graph))
+    drifted_graph["edges"] = drifted_graph["edges"][1:]
+    drifted = tmp_path / "observed_drifted.json"
+    drifted.write_text(json.dumps(drifted_graph))
+    rc = ws.main(["diff", "--expected", str(expected_md),
+                  "--observed", str(drifted)])
+    verdict = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert verdict["identical"] is False
+    assert verdict["missing_edges"]

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -5,6 +5,7 @@ markers =
     build_packages: Colcon workspace build tests
     integration: Cross-component integration tests (robot container + a host-side component; no sim/GPU)
     liveliness: Container and process health (Docker, tmux, sentinel ROS 2 nodes)
+    wiring: Observed wiring snapshot of the running ROS graph, drift-checked against a committed golden (test_wiring_snapshot.py)
     sensors: Sim and robot sensor topic rates, LiDAR validation, sim RTF
     takeoff_hover_land: End-to-end takeoff / hover / land action tests
     autonomy: Fixed-pattern trajectory path-tracker benchmark (test_fixed_trajectory.py)

--- a/tests/system/test_wiring_snapshot.py
+++ b/tests/system/test_wiring_snapshot.py
@@ -14,6 +14,7 @@ if present, ``diff_graphs`` must report identical or the test fails with the
 JSON drift verdict.
 """
 import json
+import os
 import subprocess
 import time
 
@@ -181,9 +182,30 @@ def _git_short_sha():
             ["git", "rev-parse", "--short", "HEAD"],
             cwd=AIRSTACK_ROOT, capture_output=True, text=True, timeout=10,
         )
-        return result.stdout.strip() or "unknown"
+        if result.stdout.strip():
+            return result.stdout.strip()
     except (OSError, subprocess.TimeoutExpired):
-        return "unknown"
+        pass
+    # The tests container has no git binary; read .git/HEAD directly (repo is
+    # mounted read-only, which is fine for reads).
+    try:
+        git_dir = os.path.join(AIRSTACK_ROOT, ".git")
+        head = open(os.path.join(git_dir, "HEAD")).read().strip()
+        if head.startswith("ref:"):
+            ref = head.split(None, 1)[1]
+            ref_path = os.path.join(git_dir, ref)
+            if os.path.exists(ref_path):
+                return open(ref_path).read().strip()[:12]
+            packed = os.path.join(git_dir, "packed-refs")
+            if os.path.exists(packed):
+                for line in open(packed):
+                    if line.strip().endswith(" " + ref):
+                        return line.split()[0][:12]
+        elif head:
+            return head[:12]
+    except OSError:
+        pass
+    return "unknown"
 
 
 @pytest.mark.timeout(1800)

--- a/tests/system/test_wiring_snapshot.py
+++ b/tests/system/test_wiring_snapshot.py
@@ -1,0 +1,267 @@
+"""Observed wiring snapshot + golden drift check (RFC #379 §4.4).
+
+Runs after ``system.test_liveliness`` (see ``_MODULE_ORDER``). Once the
+sentinel nodes are up, snapshots the *running* ROS graph per robot —
+``ros2 node list`` + ``ros2 topic list`` + one batched ``docker exec`` of
+``ros2 topic info --verbose`` probes per robot — merges it into one graph
+(node/edge names keep their robot namespaces), and renders it to
+``<run_dir>/wiring/observed_full_default.md`` via ``tests/wiring_snapshot.py``.
+
+Golden logic: if ``tests/goldens/wiring/full_default.<sim>.<N>robot.md`` is
+missing, the test logs a bootstrap instruction and PASSES (goldens are
+committed from a validated local run — see ``tests/goldens/wiring/README.md``);
+if present, ``diff_graphs`` must report identical or the test fails with the
+JSON drift verdict.
+"""
+import json
+import subprocess
+import time
+
+import pytest
+
+from conftest import (
+    AIRSTACK_ROOT,
+    ROS_DISTRO_SETUP,
+    current_test_id,
+    docker_exec,
+    get_metrics,
+    get_robot_containers,
+    logger,
+    repo_path,
+    ros2_exec,
+)
+from harness.session import run_dir
+from system.test_liveliness import _check_sentinel_nodes, _poll_until
+
+import wiring_snapshot as ws
+
+pytestmark = pytest.mark.wiring
+
+# Topics per batched `docker exec` (each probe backgrounded into its own /tmp
+# file — the parallel_sample_hz idiom).
+_TOPICS_PER_EXEC = 40
+# Wall seconds each backgrounded `ros2 topic info --verbose` gets.
+_INFO_TIMEOUT_S = 20
+# Node-set settle poll: snapshot only once two consecutive samples agree.
+_SETTLE_TIMEOUT_S = 120
+_SETTLE_INTERVAL_S = 10
+
+
+def _node_list(container, domain_id, setup_bash):
+    result = ros2_exec(
+        container,
+        "ros2 node list 2>/dev/null",
+        domain_id=domain_id,
+        setup_bash=setup_bash,
+        timeout=30,
+    )
+    return ws.parse_node_list(result.stdout)
+
+
+def _topic_list(container, domain_id, setup_bash):
+    result = ros2_exec(
+        container,
+        "ros2 topic list 2>/dev/null",
+        domain_id=domain_id,
+        setup_bash=setup_bash,
+        timeout=30,
+    )
+    return sorted({
+        line.strip() for line in result.stdout.splitlines()
+        if line.strip().startswith("/")
+    })
+
+
+def _batched_topic_info(container, topics, domain_id, setup_bash):
+    """``ros2 topic info --verbose`` for every topic, batched per docker exec.
+
+    One ``docker exec`` per chunk of ``_TOPICS_PER_EXEC`` topics: each probe is
+    backgrounded into its own /tmp file, then the files are catted back with
+    ``===FILE ...===`` sentinels (same idiom as ``parallel_sample_hz``).
+    Returns ``{topic: verbose_output_text}``.
+    """
+    outputs = {}
+    for start in range(0, len(topics), _TOPICS_PER_EXEC):
+        chunk = topics[start:start + _TOPICS_PER_EXEC]
+        temp_files = {}
+        probes = []
+        for i, topic in enumerate(chunk, start=start):
+            fname = f"/tmp/wiring_{i}.out"
+            temp_files[topic] = fname
+            probes.append(
+                f"(ROS_DOMAIN_ID={domain_id} timeout {_INFO_TIMEOUT_S} "
+                f"ros2 topic info --verbose {topic} > {fname} 2>&1) &"
+            )
+        # Newlines, not `&& ... &`: bash precedence makes `A && B && C & D &`
+        # only apply the && chain to C (see parallel_sample_hz).
+        lines = [f"source {ROS_DISTRO_SETUP}", f"source {setup_bash}"]
+        lines += probes + ["wait"]
+        for fname in temp_files.values():
+            lines.append(f"echo '===FILE {fname}==='")
+            lines.append(f"cat {fname} 2>/dev/null || true")
+        result = docker_exec(container, "\n".join(lines),
+                             timeout=_INFO_TIMEOUT_S + 60)
+        for piece in result.stdout.split("===FILE ")[1:]:
+            header, _, content = piece.partition("===")
+            fname = header.strip()
+            topic = next((t for t, f in temp_files.items() if f == fname), None)
+            if topic is not None:
+                outputs[topic] = content
+    return outputs
+
+
+def _wait_for_settled_node_sets(env):
+    """Poll per-robot node sets until two consecutive samples agree.
+
+    Sentinel presence proves the core stack is up, but late modules can still
+    be joining the graph; snapshotting mid-bring-up would produce flaky drift.
+    Proceeds (with a warning) if the graph is still changing after the budget.
+    """
+    cfg = env["cfg"]
+    containers = get_robot_containers(env["robot_pattern"])
+    previous = None
+    deadline = time.time() + _SETTLE_TIMEOUT_S
+    while time.time() < deadline:
+        sample = tuple(
+            tuple(_node_list(containers[n - 1], n, cfg["robot_setup_bash"]))
+            for n in range(1, env["num_robots"] + 1)
+        )
+        if sample == previous:
+            logger.info("Node graph settled (%d nodes total)",
+                        sum(len(s) for s in sample))
+            return
+        previous = sample
+        time.sleep(_SETTLE_INTERVAL_S)
+    logger.warning("Node graph still changing after %ds; snapshotting anyway",
+                   _SETTLE_TIMEOUT_S)
+
+
+def _capture_merged_graph(env):
+    """Snapshot every robot's ROS graph and merge into one normalized graph.
+
+    Robot container index n-1 hosts ``robot_n`` on ROS_DOMAIN_ID n; node and
+    edge names carry their robot namespaces as-is, so the merge is a plain
+    union (first-seen wins for a topic observed on multiple domains, e.g.
+    ``/clock``).
+    """
+    cfg = env["cfg"]
+    containers = get_robot_containers(env["robot_pattern"])
+    assert len(containers) >= env["num_robots"], (
+        f"only {len(containers)}/{env['num_robots']} robot containers visible"
+    )
+    nodes = set()
+    topics = {}
+    edges = []
+    for n in range(1, env["num_robots"] + 1):
+        container = containers[n - 1]
+        setup_bash = cfg["robot_setup_bash"]
+        robot_nodes = _node_list(container, n, setup_bash)
+        robot_topics = _topic_list(container, n, setup_bash)
+        logger.info("robot_%d graph: %d nodes, %d topics (%s, domain %d)",
+                    n, len(robot_nodes), len(robot_topics), container, n)
+        nodes.update(robot_nodes)
+        infos = _batched_topic_info(container, robot_topics, n, setup_bash)
+        for topic in robot_topics:
+            text = infos.get(topic)
+            if not text:
+                logger.warning("no `topic info --verbose` output for %s "
+                               "(robot_%d)", topic, n)
+                continue
+            entry, topic_edges = ws.parse_topic_info_verbose(topic, text)
+            topics.setdefault(topic, entry)
+            edges.extend(topic_edges)
+    graph = {"version": 1, "nodes": sorted(nodes), "topics": topics,
+             "edges": edges}
+    return ws.normalize_graph(graph)
+
+
+def _git_short_sha():
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=AIRSTACK_ROOT, capture_output=True, text=True, timeout=10,
+        )
+        return result.stdout.strip() or "unknown"
+    except (OSError, subprocess.TimeoutExpired):
+        return "unknown"
+
+
+@pytest.mark.timeout(1800)
+class TestWiringSnapshot:
+
+    @pytest.mark.dependency(name="wiring_nodes")
+    def test_sentinel_nodes_present(self, airstack_env):
+        """Wait up to 300s for the expected sentinel nodes per robot."""
+        last_msg = [""]
+
+        def ready():
+            ok, msg = _check_sentinel_nodes(airstack_env)
+            last_msg[0] = msg
+            return ok
+
+        _poll_until(
+            ready,
+            timeout=300,
+            interval=5,
+            fail_msg=lambda: f"sentinel nodes not ready after 300s: {last_msg[0]}",
+        )
+
+    @pytest.mark.dependency(depends=["wiring_nodes"])
+    def test_wiring_matches_golden(self, airstack_env):
+        """Snapshot the running graph, render wiring.md, diff against golden."""
+        sim = airstack_env["sim"]
+        num_robots = airstack_env["num_robots"]
+        m = get_metrics()
+        tid = current_test_id()
+
+        _wait_for_settled_node_sets(airstack_env)
+        t0 = time.time()
+        graph = _capture_merged_graph(airstack_env)
+        m.record(tid, "wiring_capture_duration_s",
+                 round(time.time() - t0, 2), unit="s")
+
+        meta = {
+            "stack": "full_default",
+            "generated-by": "tests/system/test_wiring_snapshot.py",
+            "date": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "sim": sim,
+            "num_robots": num_robots,
+            "source-sha": _git_short_sha(),
+        }
+        out_dir = run_dir() / "wiring"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        observed_path = out_dir / "observed_full_default.md"
+        observed_path.write_text(ws.render_wiring_md(graph, meta))
+        logger.info("Wrote observed wiring snapshot to %s", observed_path)
+
+        # Counts are drift telemetry: a silently vanishing node/edge should
+        # read as a regression, hence higher_is_better.
+        m.record(tid, "wiring_node_count", len(graph["nodes"]),
+                 unit="count", direction="higher_is_better")
+        m.record(tid, "wiring_edge_count", len(graph["edges"]),
+                 unit="count", direction="higher_is_better")
+        m.record(tid, "wiring_topic_count", len(graph["topics"]),
+                 unit="count", direction="higher_is_better")
+
+        golden_path = repo_path(
+            "tests", "goldens", "wiring",
+            f"full_default.{sim}.{num_robots}robot.md",
+        )
+        if not golden_path.exists():
+            logger.info(
+                "INSTRUCTION: no golden at %s — bootstrap by validating the "
+                "observed snapshot (%s) and copying it to that path, then "
+                "commit it (see tests/goldens/wiring/README.md).",
+                golden_path, observed_path,
+            )
+            return
+
+        expected = ws.extract_graph_from_md(golden_path.read_text())
+        verdict = ws.diff_graphs(expected, graph)
+        if not verdict["identical"]:
+            pytest.fail(
+                f"observed wiring drifted from golden {golden_path.name} — "
+                "if the change is intentional, regenerate the golden from "
+                f"{observed_path} and commit it:\n"
+                + json.dumps(verdict, indent=2)
+            )

--- a/tests/wiring_snapshot.py
+++ b/tests/wiring_snapshot.py
@@ -42,8 +42,15 @@ DEFAULT_EXCLUDES = ("/parameter_events", "/rosout")
 # Node-name (final segment) prefixes that are per-process/per-pid artifacts of
 # the launch system or CLI tooling, not stack wiring. transform_listener_impl_*
 # and launch_ros_* carry hex/pid suffixes; _ros2cli* nodes are the probes
-# themselves (ros2 topic info/echo spin one up).
-_EXCLUDED_NODE_PREFIXES = ("launch_ros_", "transform_listener_impl", "_ros2cli")
+# themselves (ros2 topic info/echo spin one up); _CREATED_BY_BARE_DDS_APP_ is
+# the placeholder name rmw reports for non-rclcpp DDS participants (sim
+# bridges, uXRCE agents) — real endpoints, but not stack nodes.
+_EXCLUDED_NODE_PREFIXES = (
+    "launch_ros_",
+    "transform_listener_impl",
+    "_ros2cli",
+    "_CREATED_BY_BARE_DDS_APP_",
+)
 
 _QOS_UNKNOWN = "UNKNOWN"
 

--- a/tests/wiring_snapshot.py
+++ b/tests/wiring_snapshot.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Standalone observed-wiring snapshot renderer and drift differ.
+
+Turns a snapshot of a *running* ROS 2 graph (``ros2 node list`` plus
+``ros2 topic info --verbose`` per topic) into a committed ``wiring.md`` — a
+mermaid dataflow diagram with a machine-readable JSON trailer — and diffs two
+such snapshots for drift (RFC #379 §4.4: the wiring picture is observed, never
+generated from configuration, so it cannot lie or rot). Used by
+``tests/system/test_wiring_snapshot.py``, but deliberately dependency-free
+(stdlib only) and runnable outside the AirStack harness: the input is plain
+``ros2`` CLI output, so the same tool can snapshot any ROS 2 system::
+
+    python3 wiring_snapshot.py render --graph-json graph.json --out wiring.md \
+        --meta sim=isaacsim --meta num_robots=1
+    python3 wiring_snapshot.py diff --expected wiring.md --observed observed.md
+
+Exit code 0 iff the two graphs are identical after normalization; a JSON
+verdict is printed to stdout either way.
+
+Graph data model (``version`` 1)::
+
+    {"version": 1,
+     "nodes": ["/robot_1/...", ...],
+     "topics": {"/robot_1/odometry": {"type": "...", "qos": {...}}, ...},
+     "edges": [{"node": ..., "topic": ..., "dir": "pub"|"sub",
+                "type": ..., "qos_profile": {...}}, ...]}
+
+QoS is normalized to ``{reliability, durability, history, depth}`` strings;
+GIDs and type hashes are dropped (non-deterministic across bring-ups).
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+# Topics that exist on every ROS 2 system and carry no wiring information.
+# /tf and /tf_static are deliberately NOT excluded — frame plumbing is wiring.
+DEFAULT_EXCLUDES = ("/parameter_events", "/rosout")
+
+# Node-name (final segment) prefixes that are per-process/per-pid artifacts of
+# the launch system or CLI tooling, not stack wiring. transform_listener_impl_*
+# and launch_ros_* carry hex/pid suffixes; _ros2cli* nodes are the probes
+# themselves (ros2 topic info/echo spin one up).
+_EXCLUDED_NODE_PREFIXES = ("launch_ros_", "transform_listener_impl", "_ros2cli")
+
+_QOS_UNKNOWN = "UNKNOWN"
+
+_HISTORY_RE = re.compile(r"History\s*\(Depth\):\s*([A-Za-z_]+)(?:\s*\((\d+)\))?")
+
+
+def _is_excluded_node(name):
+    """True for launch/CLI helper nodes whose names are pid/hex-suffixed."""
+    segment = name.rsplit("/", 1)[-1]
+    return segment.startswith(_EXCLUDED_NODE_PREFIXES)
+
+
+def parse_node_list(text):
+    """Parse ``ros2 node list`` output into a sorted list of node names."""
+    return sorted({
+        line.strip() for line in (text or "").splitlines()
+        if line.strip().startswith("/")
+    })
+
+
+def _empty_qos():
+    return {"reliability": _QOS_UNKNOWN, "durability": _QOS_UNKNOWN,
+            "history": _QOS_UNKNOWN, "depth": _QOS_UNKNOWN}
+
+
+def _full_node_name(namespace, name):
+    ns = (namespace or "/").rstrip("/")
+    return f"{ns}/{name}"
+
+
+def parse_topic_info_verbose(topic_name, text):
+    """Parse ``ros2 topic info --verbose`` output for one topic.
+
+    The output (ROS 2 Jazzy) is a sequence of endpoint blocks, each opened by
+    a ``Node name:`` line and carrying ``Node namespace:``, ``Topic type:``,
+    ``Endpoint type: PUBLISHER|SUBSCRIPTION``, a ``GID:`` and an indented
+    ``QoS profile:`` block. Unknown lines are ignored (defensive parsing);
+    GIDs and type hashes are dropped as non-deterministic.
+
+    Returns ``(topic_entry, edges)`` where ``topic_entry`` is the ``topics``
+    dict value ``{"type": ..., "qos": {...}}`` (QoS taken from the first
+    publisher, else the first endpoint) and ``edges`` is a list of edge dicts.
+    """
+    topic_type = None
+    endpoints = []
+    current = None
+    for raw in (text or "").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("Type:") and topic_type is None:
+            topic_type = line.split(":", 1)[1].strip()
+        elif line.startswith("Node name:"):
+            current = {"name": line.split(":", 1)[1].strip(), "namespace": "/",
+                       "type": None, "endpoint": None, "qos": _empty_qos()}
+            endpoints.append(current)
+        elif current is None:
+            continue
+        elif line.startswith("Node namespace:"):
+            current["namespace"] = line.split(":", 1)[1].strip() or "/"
+        elif line.startswith("Topic type:"):
+            current["type"] = line.split(":", 1)[1].strip()
+        elif line.startswith("Endpoint type:"):
+            current["endpoint"] = line.split(":", 1)[1].strip().upper()
+        elif line.startswith("Reliability:"):
+            current["qos"]["reliability"] = line.split(":", 1)[1].strip()
+        elif line.startswith("Durability:"):
+            current["qos"]["durability"] = line.split(":", 1)[1].strip()
+        elif line.startswith("History"):
+            m = _HISTORY_RE.match(line)
+            if m:
+                current["qos"]["history"] = m.group(1)
+                current["qos"]["depth"] = m.group(2) or _QOS_UNKNOWN
+
+    dir_map = {"PUBLISHER": "pub", "SUBSCRIPTION": "sub"}
+    edges = []
+    first_pub_qos = None
+    first_qos = None
+    for ep in endpoints:
+        direction = dir_map.get(ep["endpoint"])
+        if direction is None:
+            continue
+        if first_qos is None:
+            first_qos = ep["qos"]
+        if direction == "pub" and first_pub_qos is None:
+            first_pub_qos = ep["qos"]
+        edges.append({
+            "node": _full_node_name(ep["namespace"], ep["name"]),
+            "topic": topic_name,
+            "dir": direction,
+            "type": ep["type"] or topic_type,
+            "qos_profile": dict(ep["qos"]),
+        })
+    topic_entry = {
+        "type": topic_type,
+        "qos": dict(first_pub_qos or first_qos or _empty_qos()),
+    }
+    return topic_entry, edges
+
+
+def _edge_sort_key(edge):
+    return (edge.get("topic") or "", edge.get("dir") or "", edge.get("node") or "")
+
+
+def normalize_graph(graph, exclude_topics=DEFAULT_EXCLUDES):
+    """Return a normalized copy of ``graph``: infra topics and per-pid helper
+    nodes removed, edges deduped, everything deterministically sorted.
+
+    Idempotent — ``diff_graphs`` normalizes both sides, so re-normalizing an
+    already-normalized graph must be a no-op.
+    """
+    excluded = set(exclude_topics)
+    topics = {
+        name: {"type": entry.get("type"), "qos": dict(entry.get("qos") or {})}
+        for name, entry in (graph.get("topics") or {}).items()
+        if name not in excluded
+    }
+    seen = set()
+    edges = []
+    for edge in sorted(graph.get("edges") or [], key=_edge_sort_key):
+        node = edge.get("node") or ""
+        topic = edge.get("topic") or ""
+        if topic in excluded or _is_excluded_node(node):
+            continue
+        key = (node, topic, edge.get("dir"))
+        if key in seen:
+            continue
+        seen.add(key)
+        edges.append({
+            "node": node,
+            "topic": topic,
+            "dir": edge.get("dir"),
+            "type": edge.get("type"),
+            "qos_profile": dict(edge.get("qos_profile") or {}),
+        })
+    nodes = {n for n in (graph.get("nodes") or []) if not _is_excluded_node(n)}
+    nodes |= {e["node"] for e in edges}
+    return {
+        "version": graph.get("version", 1),
+        "nodes": sorted(nodes),
+        "topics": topics,
+        "edges": edges,
+    }
+
+
+# ── mermaid rendering ──────────────────────────────────────────────────────
+
+def _esc(label):
+    """Escape mermaid-special characters inside a quoted label."""
+    return str(label).replace('"', "#quot;")
+
+
+def _short_type(type_name):
+    """``nav_msgs/msg/Odometry`` → ``Odometry``."""
+    return (type_name or "?").rsplit("/", 1)[-1]
+
+
+def _default_group(node):
+    """Subgraph for a node: the namespace segment after the robot namespace
+    (``/robot_1/perception/foo`` → ``perception``), the sole namespace segment
+    for shallow nodes (``/robot_1/foo`` → ``robot_1``), else ``root``."""
+    segments = [s for s in node.split("/") if s]
+    if len(segments) >= 3:
+        return segments[1]
+    if len(segments) == 2:
+        return segments[0]
+    return "root"
+
+
+def render_mermaid(graph, group_fn=None):
+    """Render the graph as deterministic mermaid ``graph LR`` text.
+
+    Nodes are grouped into subgraphs by ``group_fn`` (default: namespace
+    segment after the robot namespace). Topics appear as edge labels
+    (``topic<br/>ShortType``) with one edge per pub×sub pair; a topic with
+    publishers but no subscribers (or vice versa) gets a dangling stadium
+    annotation node so the loose end is visible.
+    """
+    group_fn = group_fn or _default_group
+    nodes = sorted(set(graph.get("nodes") or [])
+                   | {e["node"] for e in (graph.get("edges") or [])})
+    ids = {n: f"n{i}" for i, n in enumerate(nodes)}
+    groups = {}
+    for n in nodes:
+        groups.setdefault(group_fn(n), []).append(n)
+
+    lines = ["graph LR"]
+    for gi, gname in enumerate(sorted(groups)):
+        lines.append(f'  subgraph g{gi}["{_esc(gname)}"]')
+        for n in groups[gname]:
+            lines.append(f'    {ids[n]}["{_esc(n)}"]')
+        lines.append("  end")
+
+    by_topic = {}
+    for e in graph.get("edges") or []:
+        info = by_topic.setdefault(e["topic"], {"pub": set(), "sub": set(),
+                                                "type": e.get("type")})
+        info[e["dir"]].add(e["node"])
+
+    dangling = 0
+    for topic in sorted(by_topic):
+        info = by_topic[topic]
+        label = _esc(f"{topic}<br/>{_short_type(info['type'])}")
+        pubs = sorted(info["pub"])
+        subs = sorted(info["sub"])
+        if pubs and subs:
+            for pub in pubs:
+                for sub in subs:
+                    lines.append(f'  {ids[pub]} -->|"{label}"| {ids[sub]}')
+        elif pubs:
+            annotation = f'd{dangling}(["{_esc(topic)} (no subscribers)"])'
+            dangling += 1
+            for pub in pubs:
+                lines.append(f'  {ids[pub]} -->|"{label}"| {annotation}')
+                annotation = f"d{dangling - 1}"  # define once, reference after
+        elif subs:
+            annotation = f'd{dangling}(["{_esc(topic)} (no publishers)"])'
+            dangling += 1
+            for sub in subs:
+                lines.append(f'  {annotation} -->|"{label}"| {ids[sub]}')
+                annotation = f"d{dangling - 1}"
+    return "\n".join(lines) + "\n"
+
+
+# ── wiring.md rendering / parsing ──────────────────────────────────────────
+
+_TRAILER_OPEN = "<!-- wiring-graph-v1"
+_TRAILER_CLOSE = "wiring-graph-v1 -->"
+_TRAILER_RE = re.compile(
+    re.escape(_TRAILER_OPEN) + r"\n(.*?)\n" + re.escape(_TRAILER_CLOSE),
+    re.DOTALL,
+)
+
+# Provenance keys rendered first, in this order; extra meta keys follow sorted.
+_META_ORDER = ("generated-by", "date", "sim", "num_robots", "source-sha")
+
+
+def render_wiring_md(graph, meta):
+    """Render the full ``wiring.md`` text: title, provenance from ``meta``,
+    the mermaid fence, and a machine-readable canonical-JSON trailer that
+    ``extract_graph_from_md`` round-trips exactly."""
+    lines = [f"# Wiring snapshot: {meta.get('stack', 'full_default')}", ""]
+    extra = sorted(set(meta) - set(_META_ORDER) - {"stack"})
+    for key in list(_META_ORDER) + extra:
+        if key in meta:
+            lines.append(f"- **{key}**: {meta[key]}")
+    lines += ["", "```mermaid", render_mermaid(graph).rstrip("\n"), "```", ""]
+    canonical = json.dumps(graph, sort_keys=True, indent=0)
+    lines += [_TRAILER_OPEN, canonical, _TRAILER_CLOSE, ""]
+    return "\n".join(lines)
+
+
+def extract_graph_from_md(text):
+    """Parse the graph JSON back out of a ``wiring.md`` trailer."""
+    m = _TRAILER_RE.search(text or "")
+    if not m:
+        raise ValueError(
+            f"no `{_TRAILER_OPEN} ... {_TRAILER_CLOSE}` trailer found"
+        )
+    return json.loads(m.group(1))
+
+
+# ── drift diffing ──────────────────────────────────────────────────────────
+
+def _edge_key(edge):
+    return f'{edge["dir"]}:{edge["node"]}:{edge["topic"]}'
+
+
+def diff_graphs(expected, observed):
+    """Compare two graphs in normalized form; return a drift verdict dict.
+
+    ``verdict["identical"]`` is the pass/fail judgment; the remaining keys
+    name exactly what drifted (nodes, edges, per-edge QoS, per-topic types).
+    """
+    exp = normalize_graph(expected)
+    obs = normalize_graph(observed)
+
+    exp_nodes, obs_nodes = set(exp["nodes"]), set(obs["nodes"])
+    exp_edges = {_edge_key(e): e for e in exp["edges"]}
+    obs_edges = {_edge_key(e): e for e in obs["edges"]}
+
+    qos_mismatches = []
+    for key in sorted(set(exp_edges) & set(obs_edges)):
+        if exp_edges[key]["qos_profile"] != obs_edges[key]["qos_profile"]:
+            qos_mismatches.append({
+                "edge": key,
+                "expected": exp_edges[key]["qos_profile"],
+                "observed": obs_edges[key]["qos_profile"],
+            })
+
+    type_mismatches = []
+    for topic in sorted(set(exp["topics"]) & set(obs["topics"])):
+        exp_type = exp["topics"][topic].get("type")
+        obs_type = obs["topics"][topic].get("type")
+        if exp_type != obs_type:
+            type_mismatches.append({
+                "topic": topic, "expected": exp_type, "observed": obs_type,
+            })
+
+    verdict = {
+        "identical": False,
+        "missing_nodes": sorted(exp_nodes - obs_nodes),
+        "extra_nodes": sorted(obs_nodes - exp_nodes),
+        "missing_edges": sorted(set(exp_edges) - set(obs_edges)),
+        "extra_edges": sorted(set(obs_edges) - set(exp_edges)),
+        "qos_mismatches": qos_mismatches,
+        "type_mismatches": type_mismatches,
+    }
+    verdict["identical"] = not any(
+        verdict[k] for k in verdict if k != "identical"
+    )
+    return verdict
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+def _load_graph(path):
+    """Load a graph from a ``wiring.md`` (trailer) or a raw ``graph.json``."""
+    with open(path) as fh:
+        text = fh.read()
+    if _TRAILER_OPEN in text:
+        return extract_graph_from_md(text)
+    return json.loads(text)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    render = sub.add_parser("render", help="Render a graph JSON to wiring.md")
+    render.add_argument("--graph-json", required=True,
+                        help="Path to the graph JSON (data model above)")
+    render.add_argument("--out", required=True, help="wiring.md output path")
+    render.add_argument("--meta", action="append", default=[], metavar="K=V",
+                        help="Provenance entries, repeatable (e.g. sim=isaacsim)")
+
+    diff = sub.add_parser("diff", help="Diff two snapshots; exit 0 iff identical")
+    diff.add_argument("--expected", required=True,
+                      help="Committed wiring.md (or graph.json)")
+    diff.add_argument("--observed", required=True,
+                      help="Observed wiring.md or graph.json")
+
+    args = ap.parse_args(argv)
+
+    if args.cmd == "render":
+        graph = _load_graph(args.graph_json)
+        meta = {}
+        for kv in args.meta:
+            key, _, value = kv.partition("=")
+            meta[key] = value
+        out_dir = os.path.dirname(os.path.abspath(args.out))
+        os.makedirs(out_dir, exist_ok=True)
+        with open(args.out, "w") as fh:
+            fh.write(render_wiring_md(graph, meta))
+        return 0
+
+    verdict = diff_graphs(_load_graph(args.expected), _load_graph(args.observed))
+    print(json.dumps(verdict, indent=2))
+    return 0 if verdict["identical"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_module.py
+++ b/tools/validate_module.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Carnegie Mellon University
+# MIT License - see LICENSE in the repository root for full text.
+"""Validate an AirStack module manifest (``module.yaml``) against the module schema.
+
+The manifest contract is RFC #379 §2 — a *thin* manifest: deps, identity, and test
+metadata only, never wiring. The schema lives at
+``common/module_schema/module.schema.json`` and this validator interprets it with a
+small generic walker (python3 stdlib + PyYAML — deliberately no ``jsonschema``
+dependency, so module authors and CI need nothing beyond what the repo already uses).
+
+The walker understands the draft-07 subset the schema keeps to — ``type``,
+``required``, ``properties``, ``enum``, ``pattern``, ``items``,
+``additionalProperties``, ``minLength``, ``minItems`` — so schema evolution does not
+require code changes here. Only two kinds of checks are custom, keyed off
+``x-airstack-*`` annotations in the schema rather than hardcoded field names:
+
+- ``x-airstack-format``: ``semver-range`` (airstack_compat) and
+  ``safe-relative-path`` (no absolute paths, no ``..`` escapes).
+- ``x-airstack-check-exists`` / ``x-airstack-warn-missing-dir``: cross-file facts,
+  applied only when the target is a module *directory* — declared dockerfile /
+  compose / hooks / docs paths must exist (error); ``tests.packages`` entries that
+  name no directory in the module are a warning, not an error.
+
+CLI::
+
+    validate_module.py <module_dir_or_module.yaml>
+
+Human-readable errors and warnings go to stderr; a JSON verdict
+``{"valid": bool, "errors": [{"path", "message"}]}`` goes to stdout; exit 0/1.
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+DEFAULT_SCHEMA_PATH = (
+    Path(__file__).resolve().parent.parent / "common" / "module_schema" / "module.schema.json"
+)
+
+MANIFEST_NAME = "module.yaml"
+
+# ── generic walker ─────────────────────────────────────────────────────────
+
+_JSON_TYPES = {
+    "object": dict,
+    "array": list,
+    "string": str,
+    "integer": int,
+    "number": (int, float),
+    "boolean": bool,
+    "null": type(None),
+}
+
+_SEMVER = (
+    r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?"
+    r"(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?"
+)
+_COMPARATOR_RE = re.compile(r"^(?:>=|<=|>|<|==|=|\^|~)?" + _SEMVER + r"$")
+
+
+def _check_semver_range(value):
+    """Validate a semver range like ``>=0.19.0 <0.21.0`` or ``>=0.19.0-alpha.18 <0.20.0``.
+
+    Space-separated comparators; each is an optional operator followed by a *full*
+    ``X.Y.Z`` semver (prerelease/build allowed). Branch names (``main``, ``latest``)
+    and partial versions (``0.19``) are invalid.
+    """
+    tokens = value.split()
+    if not tokens:
+        return "empty semver range"
+    for token in tokens:
+        if not _COMPARATOR_RE.match(token):
+            return (
+                f"invalid semver range component {token!r} — expected an optional "
+                "operator (>=, <=, >, <, ==, =, ^, ~) followed by a full X.Y.Z "
+                "semver, e.g. \">=0.19.0 <0.21.0\""
+            )
+    return None
+
+
+def _check_safe_relative_path(value):
+    """A repo/module-relative path: non-empty, not absolute, no ``..`` escapes."""
+    if not value:
+        return "path must be non-empty"
+    if value.startswith(("/", "\\", "~")) or re.match(r"^[A-Za-z]:[/\\]", value):
+        return f"path must be relative, got {value!r}"
+    if ".." in Path(value).parts:
+        return f"path must not escape the module checkout via '..', got {value!r}"
+    return None
+
+
+_FORMAT_CHECKS = {
+    "semver-range": _check_semver_range,
+    "safe-relative-path": _check_safe_relative_path,
+}
+
+
+def _join(path, key):
+    return f"{path}.{key}" if path else str(key)
+
+
+def _type_ok(value, type_spec):
+    types = type_spec if isinstance(type_spec, list) else [type_spec]
+    for name in types:
+        expected = _JSON_TYPES.get(name)
+        if expected is None:
+            continue
+        # bool is a subclass of int in Python; keep JSON semantics strict.
+        if isinstance(value, bool) and name in ("integer", "number"):
+            continue
+        if isinstance(value, expected):
+            return True
+    return False
+
+
+def _type_names(type_spec):
+    return type_spec if isinstance(type_spec, list) else [type_spec]
+
+
+class _Context:
+    """Collects errors, warnings, and cross-file annotations during the walk."""
+
+    def __init__(self):
+        self.errors = []
+        self.warnings = []
+        self.existence_checks = []  # (path, relative_path) — must exist in the module dir
+        self.dir_warnings = []      # (path, name) — warn when no matching directory
+
+    def error(self, path, message):
+        self.errors.append({"path": path or "(root)", "message": message})
+
+
+def _walk(value, schema, path, ctx):
+    """Apply one schema node to one instance node, recursing into properties/items."""
+    if "type" in schema and not _type_ok(value, schema["type"]):
+        ctx.error(
+            path,
+            f"expected type {' or '.join(_type_names(schema['type']))}, "
+            f"got {type(value).__name__}",
+        )
+        return
+    if value is None:
+        return  # a nullable field left null — string/object keywords do not apply
+
+    if "enum" in schema and value not in schema["enum"]:
+        ctx.error(
+            path,
+            f"{value!r} is not one of {schema['enum']}",
+        )
+        return
+
+    if isinstance(value, str):
+        ok = True
+        if "minLength" in schema and len(value) < schema["minLength"]:
+            ctx.error(path, f"must be at least {schema['minLength']} characters")
+            ok = False
+        if "pattern" in schema and not re.search(schema["pattern"], value):
+            ctx.error(path, f"{value!r} does not match pattern {schema['pattern']!r}")
+            ok = False
+        fmt = schema.get("x-airstack-format")
+        if fmt:
+            msg = _FORMAT_CHECKS[fmt](value)
+            if msg:
+                ctx.error(path, msg)
+                ok = False
+        if ok:
+            # Cross-file annotations only make sense for values that passed the
+            # syntactic checks — a path with '..' must never reach a filesystem probe.
+            if schema.get("x-airstack-check-exists"):
+                ctx.existence_checks.append((path, value))
+            if schema.get("x-airstack-warn-missing-dir"):
+                ctx.dir_warnings.append((path, value))
+
+    elif isinstance(value, dict):
+        properties = schema.get("properties", {})
+        for key in schema.get("required", []):
+            if key not in value:
+                ctx.error(_join(path, key), "required property is missing")
+        if schema.get("additionalProperties") is False:
+            for key in value:
+                if key not in properties:
+                    ctx.error(_join(path, key), "unknown property (additionalProperties: false)")
+        for key, subschema in properties.items():
+            if key in value:
+                _walk(value[key], subschema, _join(path, key), ctx)
+
+    elif isinstance(value, list):
+        if "minItems" in schema and len(value) < schema["minItems"]:
+            ctx.error(path, f"must have at least {schema['minItems']} item(s)")
+        if "items" in schema:
+            for i, item in enumerate(value):
+                _walk(item, schema["items"], f"{path}[{i}]", ctx)
+
+
+# ── entry points ───────────────────────────────────────────────────────────
+
+def load_schema(schema_path=None):
+    with open(schema_path or DEFAULT_SCHEMA_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def validate_manifest(data, schema):
+    """Schema-only validation of a parsed manifest. Returns a ``_Context``."""
+    ctx = _Context()
+    _walk(data, schema, "", ctx)
+    return ctx
+
+
+def validate_module(target, schema_path=None):
+    """Validate a module dir (schema + cross-file facts) or a bare module.yaml.
+
+    Returns ``(verdict, warnings)`` where ``verdict`` is the stable JSON shape
+    ``{"valid": bool, "errors": [{"path", "message"}]}`` and ``warnings`` is a
+    list of human-readable strings (never affecting validity).
+    """
+    target = Path(target)
+    ctx = _Context()
+
+    if target.is_dir():
+        module_dir, manifest_path = target, target / MANIFEST_NAME
+    else:
+        module_dir, manifest_path = None, target
+
+    if not manifest_path.is_file():
+        ctx.error("(file)", f"manifest not found: {manifest_path}")
+        return {"valid": False, "errors": ctx.errors}, ctx.warnings
+
+    try:
+        with manifest_path.open(encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        ctx.error("(file)", f"invalid YAML: {exc}")
+        return {"valid": False, "errors": ctx.errors}, ctx.warnings
+
+    if not isinstance(data, dict):
+        ctx.error("(root)", "manifest top level must be a mapping")
+        return {"valid": False, "errors": ctx.errors}, ctx.warnings
+
+    schema = load_schema(schema_path)
+    ctx = validate_manifest(data, schema)
+
+    if module_dir is not None:
+        for path, rel in ctx.existence_checks:
+            if not (module_dir / rel).exists():
+                ctx.error(path, f"declared path does not exist in the module: {rel!r}")
+        for path, name in ctx.dir_warnings:
+            if not (module_dir / name).is_dir():
+                ctx.warnings.append(
+                    f"{path}: {name!r} names no directory in the module — "
+                    "tests.packages entries usually match a package directory"
+                )
+
+    return {"valid": not ctx.errors, "errors": ctx.errors}, ctx.warnings
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Validate an AirStack module.yaml against the module manifest schema."
+    )
+    parser.add_argument(
+        "target",
+        help="module directory (validates module.yaml + cross-file facts) "
+             "or a module.yaml path (schema-only)",
+    )
+    parser.add_argument(
+        "--schema",
+        default=str(DEFAULT_SCHEMA_PATH),
+        help="schema path (default: common/module_schema/module.schema.json)",
+    )
+    args = parser.parse_args(argv)
+
+    verdict, warnings = validate_module(Path(args.target), Path(args.schema))
+    for warning in warnings:
+        print(f"warning: {warning}", file=sys.stderr)
+    for error in verdict["errors"]:
+        print(f"error: {error['path']}: {error['message']}", file=sys.stderr)
+    if verdict["valid"]:
+        print(f"{args.target}: module manifest is valid", file=sys.stderr)
+    print(json.dumps(verdict, indent=2))
+    return 0 if verdict["valid"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> **Stacked PR** — merge the stack bottom-up with **merge commits** (squash-merging a lower PR orphans the commits every higher PR builds on). When the PR below merges, GitHub retargets this one to `develop` automatically. Each PR bumps `VERSION` (`0.20.0-alpha.N`), so `check-version-increment` passes at every level and each merge publishes images.

**Stack 1/9 · base: `develop`**

Lays the observability and contract foundations for Modular AirStack ([RFC #379](https://github.com/castacks/AirStack/discussions/379)) before any behavior changes: you can't safely restructure a launch graph you can't diff.

## What's inside

- **Observed wiring snapshots** (`tests/wiring_snapshot.py`, stdlib-only): captures the *running* ROS graph (nodes, pub/sub edges, types, QoS) via batched `ros2 topic info --verbose`, renders mermaid, and diffs against a committed golden. New `wiring` system-test mark + drift check; first golden captured from the then-current `AUTONOMY_ROLE=full` topology.
- **`module.yaml` manifest schema** (`common/module_schema/module.schema.json`) + `tools/validate_module.py` + a `hello_module` fixture and unit-mark contract tests. Manifests carry identity/deps/assets/hooks only — never wiring.
- **Reusable module CI** (`.github/workflows/module-system-tests.yml`, first `workflow_call` workflow in the repo): external module repos run trunk's own harness against a pinned trunk ref on the ephemeral GPU runners; same-repo/org callers only.

## Validation

- `wiring` mark green on Isaac Sim (snapshot + drift check); goldens stable across repeated bring-ups after excluding timing-dependent sim render-pipeline nodes.
- All new contract tests in the unit suite; no behavior change to any launch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
