### PR TITLE
Release 0.19.0 — version + changelog promotion

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ PROJECT_NAME="airstack"
 # If you've run ./airstack.sh setup, then this will auto-generate from the git commit hash every time a change is made 
 # to a Dockerfile or docker-compose.yaml file. Otherwise this can also be set explicitly to make a release version.
 # auto-generated from git commit hash
-VERSION="0.19.0-alpha.18"
+VERSION="0.19.0"
 # Choose "dev" or "prebuilt". "dev" is for mounted code that must be built live. "prebuilt" is for built ros_ws baked into the image
 DOCKER_IMAGE_BUILD_MODE="dev"  
 # Where to push and pull images from. Can replace with your docker hub username if using docker hub.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-08-22
+
 ### Added
 
 - Intent flags on `airstack up` — `--sim isaac|airsim`, `--robots N`, `--headless`, `--play`/`--no-play`, `--no-autolaunch`, `--wait`, `--dry-run` — deriving the coordinated env-var sets (compose profiles, URDF, single/multi Isaac launch script) as exported leaf values, with a resolved-config banner and a per-run `.airstack/runs/<ts>/effective_config.env` dump; contract-tested in `tests/meta/test_launch_intent_contract.py` (unit mark)


### PR DESCRIPTION
Promotes the 0.19 series to release: `VERSION` 0.19.0-alpha.18 → **0.19.0**, CHANGELOG `[Unreleased]` promoted to `[0.19.0] - 2026-08-22` with a fresh empty `[Unreleased]` section.

Once this merges, the follow-up PR **develop → main** ships the release; `docker-build.yml` publishes and signs the v0.19.0 images, and the GitHub Release (tag `0.19.0`) deploys the versioned docs. The main→develop sync workflow then rolls develop to `0.20.0-alpha.0`, which keeps the Modular AirStack stack (#388–#396, starting at 0.20.0-alpha.1) strictly increasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)