### PR TITLE
feat(gcs): auto-load NUM_ROBOTS-matched Foxglove layout — no manual import

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ PROJECT_NAME="airstack"
 # If you've run ./airstack.sh setup, then this will auto-generate from the git commit hash every time a change is made 
 # to a Dockerfile or docker-compose.yaml file. Otherwise this can also be set explicitly to make a release version.
 # auto-generated from git commit hash
-VERSION="0.20.0-alpha.9"
+VERSION="0.20.0-alpha.10"
 # Image-tag discriminator ONLY (appears in the image tag suffix, e.g. ..._robot-x86-64_dev).
 # No Dockerfile consumes it: "prebuilt" does NOT bake the built ros_ws into the image today —
 # a real prebuilt (workspace-baked) stage is future work. Keep "dev" (mounted code, built live).

--- a/common/ros_packages/desktop_bringup/launch/gcs.launch.xml
+++ b/common/ros_packages/desktop_bringup/launch/gcs.launch.xml
@@ -9,15 +9,15 @@
 
   <!-- ======== GUI ======== -->
   <!-- Launch foxglove-studio with the no-sandbox flag (Electron in a root
-       container). The layoutId in the deep link is a Foxglove-app layout id:
-       it selects that layout from the app's local/team layout store when
-       present, and is harmlessly ignored otherwise. The documented layout
-       flow is importing the rendered /root/airstack_layout_num_robots_<N>.json
-       (see docs/gcs/foxglove.md), which supersedes this id for multi-robot
-       runs — kept so single-robot sessions restore the last-used layout. -->
+       container). The layoutId in the deep link matches the layout that
+       gcs/foxglove_extensions/render_layout.py seeds into the app's local
+       layout store on container startup (layout_id()), so the
+       NUM_ROBOTS-matched layout is active immediately with no manual import
+       (see docs/gcs/foxglove.md). -->
+
 
   <executable
-    cmd="bash -c 'DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY foxglove-studio --no-sandbox &quot;foxglove://open?ds=foxglove-websocket&amp;ds.url=ws://localhost:8765&amp;layoutId=lay_0eLycKBK1l9dAtoR&quot;'"
+    cmd="bash -c 'DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY foxglove-studio --no-sandbox &quot;foxglove://open?ds=foxglove-websocket&amp;ds.url=ws://localhost:8765&amp;layoutId=airstack_default_${NUM_ROBOTS:-1}_robots&quot;'"
     output="screen"/>
 
   <node pkg="foxglove_bridge" exec="foxglove_bridge" output="screen" respawn="true" respawn_delay="1">

--- a/docs/gcs/foxglove.md
+++ b/docs/gcs/foxglove.md
@@ -8,18 +8,24 @@ This page describes what the node visualizes today, the topic naming convention,
 
 ## Connecting to Foxglove and loading the custom layout
 
-The GCS container regenerates `/root/airstack_layout_num_robots_<N>.json` on every startup, where `<N>` is the current `NUM_ROBOTS`, using `gcs/foxglove_extensions/airstack_default.json` as the single-robot template (see `gcs/foxglove_extensions/render_layout.py`). The file lives only in the container — it's regenerated on startup and disappears on removal.
+**The `NUM_ROBOTS`-matched layout loads automatically — no manual import.** On every GCS container startup, `gcs/foxglove_extensions/render_layout.py` renders an `<N>`-robot layout from the single-robot template (`gcs/foxglove_extensions/airstack_default.json`) and seeds it straight into the Foxglove desktop app's local layout store (`/root/.config/Foxglove/studio-datastores/layouts-local/airstack_default_<N>_robots` — bind-mounted from `gcs/docker/Foxglove`, so it persists across container restarts). `gcs.launch.xml` then opens Foxglove with a deep link that both connects to `ws://localhost:8765` and selects that layout by id, so the app comes up showing **AirStack default (`<N>` robots)** immediately.
 
-To use the locally-rendered, `NUM_ROBOTS`-matched layout:
+### Editing and saving the layout
 
-1. In the Foxglove dashboard, click **Layouts** → **Import from file...**.
-2. The file browser opens in `/root/` by default — select the `airstack_layout_num_robots_<N>.json` matching your `NUM_ROBOTS`.
-3. Back on the dashboard, click **Open connection** and enter:
-    - `ws://localhost:8765` if Foxglove is running inside the GCS container
-    - `ws://localhost:8766` if Foxglove is running on the host
-4. In the top-right corner, click the current layout name and select the imported layout from the dropdown.
+The seeded layout is an ordinary local layout — edit it and use **Save** as usual. Your saved edits are preserved: the seeder detects that the layout no longer matches what it generated and will not overwrite it on later startups (this also means template updates stop propagating to an edited layout). Two ways to manage this:
 
-Foxglove keeps the imported layout in its IndexedDB and re-activates it on subsequent launches — re-import only when you change `NUM_ROBOTS` or edit the template.
+- **Reset to the generated default:** delete the layout in Foxglove's **Layouts** menu — the next container start re-seeds a fresh copy.
+- **Keep your own variant safe forever:** **Save As** a personal copy under a different name; the seeder never touches layouts it didn't create.
+
+### Manual fallback
+
+The rendered layout is also still written to `/root/airstack_layout_num_robots_<N>.json` inside the container, so **Layouts → Import from file...** keeps working — useful when running Foxglove on the host instead of in the container (connect to `ws://localhost:8766` in that case).
+
+!!! note "Foxglove version pin"
+    `Dockerfile.gcs` pins the Foxglove desktop version (`FOXGLOVE_VERSION` build arg) because the auto-load mechanism writes the app's on-disk local-layout record format directly. Before bumping the pin, verify the format in the new version's `studio-datastores/layouts-local/` still matches what `render_layout.py::seed_layout_store` writes.
+
+!!! warning "Robot naming assumption"
+    Layout rendering assumes robots are named `robot_1..robot_N` (the default robot-name map). Fleets with custom robot names (RFC #380) still get the default-named tabs; name-aware rendering is future work.
 
 ## What gets visualized
 

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -166,9 +166,20 @@ Feature docs deliberately cite none of these — the design sources live here:
   `NavigateTask` → land, judged on the odometry track by the standalone
   `tests/waypoint_checker.py`; the standard acceptance check after
   integrating or swapping a planner module
+- Foxglove auto-loaded layout: `render_layout.py` seeds the rendered
+  `NUM_ROBOTS`-matched layout directly into the Foxglove desktop app's
+  local layout store and `gcs.launch.xml` selects it via the `layoutId`
+  deep link, so Foxglove opens on the right layout with no manual
+  **Import from file...** step; user-saved edits are hash-detected and
+  never overwritten (delete the layout in the UI to reset). Requires the
+  pinned Foxglove version — see Changed
 
 ### Changed
 
+- `Dockerfile.gcs` pins the Foxglove desktop version (`FOXGLOVE_VERSION`
+  build arg, currently 3.0.0) instead of installing `latest`, since the
+  layout auto-load writes the app's on-disk local-layout record format
+  directly (verified against 3.0.0; re-verify before bumping the pin)
 - `robot-desktop` image slimmed 17.1 GB → ~6 GB (−65%) by moving MACVO's
   torch/TensorRT/weights into the `asm_macvo` module Docker layer; a further
   dependency purge removed unused apt/pip packages (−152 MB) and `droan_gl`'s

--- a/gcs/docker/Dockerfile.gcs
+++ b/gcs/docker/Dockerfile.gcs
@@ -51,7 +51,11 @@ RUN git clone --depth 1 https://github.com/tmux-plugins/tpm /root/.tmux/plugins/
     (sleep 5 && git clone --depth 1 https://github.com/tmux-plugins/tpm /root/.tmux/plugins/tpm)
 
 # install FoxGloveStudio and ros-jazzy-foxglove-bridge
-RUN wget -q https://get.foxglove.dev/desktop/latest/foxglove-studio-latest-linux-amd64.deb -O /tmp/foxglove-studio.deb \
+# Pinned (not "latest"): gcs/foxglove_extensions/render_layout.py seeds layouts
+# into the app's local layout store, whose on-disk format we verified against
+# this exact version. Re-verify the store format before bumping.
+ARG FOXGLOVE_VERSION=3.0.0
+RUN wget -q https://get.foxglove.dev/desktop/v${FOXGLOVE_VERSION}/foxglove-studio-${FOXGLOVE_VERSION}-linux-amd64.deb -O /tmp/foxglove-studio.deb \
     && apt -o Acquire::AllowInsecureRepositories=true -o Acquire::AllowDowngradeToInsecureRepositories=true update \
     && apt -o APT::Get::AllowUnauthenticated=true install -y --no-install-recommends /tmp/foxglove-studio.deb ros-jazzy-foxglove-bridge \
     && rm /tmp/foxglove-studio.deb \

--- a/gcs/foxglove_extensions/render_layout.py
+++ b/gcs/foxglove_extensions/render_layout.py
@@ -1,15 +1,30 @@
 #!/usr/bin/env python3
-"""Render /root/airstack_layout_num_robots_<N>.json with NUM_ROBOTS tabs from a single-robot template.
+"""Render and auto-load a NUM_ROBOTS-tab Foxglove layout from a single-robot template.
 
 Foxglove layout JSON has no native templating, so we generate it at GCS startup
 based on the NUM_ROBOTS env var. Tab[0] of the input file is treated as the
 canonical robot_1 template; we replicate it for robots 1..NUM_ROBOTS, mint
 unique panel IDs per tab, and patch the 3D panel's per-robot transforms /
 topics / namespaces to cover the same range.
+
+Besides the manual-import copy in /root/, the rendered layout is seeded
+directly into the Foxglove desktop app's local layout store
+(<userData>/studio-datastores/layouts-local/<layout-id> — one plain-JSON file
+per layout; verified against foxglove-studio 3.0.0) under the deterministic id
+``airstack_default_<N>_robots``. gcs.launch.xml then opens Foxglove with a
+``layoutId=airstack_default_<N>_robots`` deep link, so the right layout is
+active on startup with no manual import.
+
+User edits are preserved: a sidecar state file (<userData>/airstack/
+seed_state.json) records the hash of what we last seeded, and a store record
+whose baseline no longer matches that hash (i.e. the user saved their own
+changes) is never overwritten. Deleting the layout in the Foxglove UI resets
+it — the next container start re-seeds a fresh copy.
 """
 
 import argparse
 import copy
+import hashlib
 import json
 import os
 import re
@@ -161,6 +176,87 @@ def expand_layout(template_json: dict, num_robots: int) -> dict:
     return out
 
 
+def layout_id(num_robots: int) -> str:
+    """Deterministic local-layout id; must match the layoutId deep link in
+    desktop_bringup gcs.launch.xml."""
+    return f'airstack_default_{num_robots}_robots'
+
+
+def _hash_layout(data: dict) -> str:
+    return hashlib.sha256(
+        json.dumps(data, sort_keys=True).encode()).hexdigest()
+
+
+def _write_json_atomic(path: str, obj) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + '.tmp'
+    with open(tmp, 'w') as f:
+        json.dump(obj, f, indent=2)
+    os.replace(tmp, path)
+
+
+def seed_layout_store(rendered: dict, num_robots: int, userdata: str) -> None:
+    """Seed the rendered layout into Foxglove desktop's local layout store.
+
+    Store format (foxglove-studio 3.0.0): one JSON file per layout at
+    <userData>/studio-datastores/layouts-local/<id> with
+    {id, name, permission, baseline:{data, savedAt}}. The dir is enumerated by
+    readdir, so nothing but layout records may live in it — the seeder's own
+    state goes to <userData>/airstack/seed_state.json instead.
+    """
+    from datetime import datetime, timezone
+
+    lid = layout_id(num_robots)
+    store_dir = os.path.join(userdata, 'studio-datastores', 'layouts-local')
+    record_path = os.path.join(store_dir, lid)
+    state_path = os.path.join(userdata, 'airstack', 'seed_state.json')
+
+    state = {}
+    if os.path.exists(state_path):
+        try:
+            with open(state_path) as f:
+                state = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            state = {}
+
+    new_hash = _hash_layout(rendered)
+
+    existing_baseline_hash = None
+    if os.path.exists(record_path):
+        try:
+            with open(record_path) as f:
+                existing_baseline_hash = _hash_layout(
+                    json.load(f)['baseline']['data'])
+        except (json.JSONDecodeError, KeyError, OSError, TypeError):
+            existing_baseline_hash = None  # corrupt record → reseed
+
+    if existing_baseline_hash is not None:
+        last_seeded = state.get(lid)
+        if existing_baseline_hash != last_seeded:
+            print(f'layout "{lid}" has user-saved edits — leaving it alone '
+                  '(delete it in Foxglove\'s Layouts menu to reset to the '
+                  'generated default)')
+            return
+        if existing_baseline_hash == new_hash:
+            print(f'layout "{lid}" already up to date in {store_dir}')
+            return
+
+    record = {
+        'id': lid,
+        'name': f'AirStack default ({num_robots} '
+                f'robot{"s" if num_robots != 1 else ""})',
+        'permission': 'CREATOR_WRITE',
+        'baseline': {
+            'data': rendered,
+            'savedAt': datetime.now(timezone.utc).isoformat(),
+        },
+    }
+    _write_json_atomic(record_path, record)
+    state[lid] = new_hash
+    _write_json_atomic(state_path, state)
+    print(f'seeded layout "{lid}" → {record_path}')
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--input', help='Source template JSON (LAYOUT_TEMPLATE env)',
@@ -173,6 +269,12 @@ def main():
                     default=os.environ.get('LAYOUT_OUTPUT'))
     ap.add_argument('--num-robots', type=int,
                     default=int(os.environ.get('NUM_ROBOTS', '1')))
+    ap.add_argument('--foxglove-userdata',
+                    help='Foxglove desktop userData dir to seed the layout '
+                    'into (FOXGLOVE_USERDATA env); pass an empty string to '
+                    'skip seeding.',
+                    default=os.environ.get('FOXGLOVE_USERDATA',
+                                           '/root/.config/Foxglove'))
     args = ap.parse_args()
     if args.output is None:
         args.output = f'/root/airstack_layout_num_robots_{args.num_robots}.json'
@@ -181,12 +283,11 @@ def main():
         template = json.load(f)
     rendered = expand_layout(template, args.num_robots)
 
-    os.makedirs(os.path.dirname(args.output), exist_ok=True)
-    tmp = args.output + '.tmp'
-    with open(tmp, 'w') as f:
-        json.dump(rendered, f, indent=2)
-    os.replace(tmp, args.output)
+    _write_json_atomic(args.output, rendered)
     print(f'rendered {args.num_robots}-robot layout → {args.output}')
+
+    if args.foxglove_userdata:
+        seed_layout_store(rendered, args.num_robots, args.foxglove_userdata)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

Foxglove on the GCS required a manual step on every fresh machine and every `NUM_ROBOTS` change: the container rendered `/root/airstack_layout_num_robots_<N>.json`, but the user had to do **Layouts → Import from file...** and then select the layout by hand. The `layoutId` deep link in `gcs.launch.xml` was hardcoded to `lay_0eLycKBK1l9dAtoR` — an id that only exists in local storage on machines where someone once imported a layout, so on a fresh checkout it silently did nothing.

Foxglove's announced [programmatic layouts](https://foxglove.dev/blog/announcing-programmatic-layouts-in-foxglove) were evaluated first and don't fit: the `foxglove.layouts` API targets the Jupyter-notebook embedded viewer on buffered data and requires a Pro/Enterprise/Academic plan + developer seat (same gating for the embed SDK and the org-layouts REST API). None of it can drive the live desktop app connected to `foxglove_bridge`.

## What changed

Foxglove now opens directly on the `NUM_ROBOTS`-matched layout, with no manual steps — and the layout stays a normal, editable, savable local layout.

| File | Change |
|---|---|
| `gcs/foxglove_extensions/render_layout.py` | New `seed_layout_store()`: writes the rendered layout into the Foxglove desktop app's local layout store (`~/.config/Foxglove/studio-datastores/layouts-local/airstack_default_<N>_robots`, bind-mounted from `gcs/docker/Foxglove`) with a content-hash sidecar (`~/.config/Foxglove/airstack/seed_state.json`) so **user-saved edits are never overwritten**; deleting the layout in the UI resets it to the generated default on next startup |
| `common/ros_packages/desktop_bringup/launch/gcs.launch.xml` | Deep link now selects the deterministic id: `layoutId=airstack_default_${NUM_ROBOTS:-1}_robots` |
| `gcs/docker/Dockerfile.gcs` | Foxglove desktop pinned via `ARG FOXGLOVE_VERSION=3.0.0` (was `latest`) — the seeder writes the app's on-disk record format, so bumps must re-verify it |
| `docs/gcs/foxglove.md` | "Connecting" section rewritten: auto-load is the default, edit/save/reset semantics, manual import kept as fallback (host-side Foxglove via port 8766) |
| `docs/release_notes/index.md`, `.env` | Release-notes bullets under 0.20.0 (Unreleased); VERSION `0.20.0-alpha.9` → `0.20.0-alpha.10` |

### How the store seeding works

The local-layout store format was verified against the foxglove-studio 3.0.0 deb (the app's own — license-gated — "well-known layouts" preload path writes the identical shape): one plain JSON file per layout, filename = layout id, content `{id, name, permission: "CREATOR_WRITE", baseline: {data: <exported-layout JSON>, savedAt}}`, directory enumerated by readdir. `baseline.data` is exactly the format `render_layout.py` already produced. The store itself is standard local-layout storage used by every unlicensed install — writing the file before app launch needs no license or plan.

Seeding rules per startup:

- record missing (fresh machine, or user deleted it in the UI) → seed
- record present and untouched by the user (hash matches sidecar) → rewrite only if the template/robot-count render changed, else no-op
- record present with user-saved edits (hash mismatch) → leave alone, log how to reset

## Validation

Stdlib-only harness run against the real `airstack_default.json` template with a scratch userData dir — **47/47 checks pass** (3 consecutive runs, 2026-08-24):

- **(a) render-and-seed** (38 checks): for N=1,2,3 — record path/shape/id/permission correct, `baseline.data` equals the manual-import file, `robot_1..robot_N` substituted with `robot_{N+1}` absent, tab count = N, name pluralization, sidecar state complete
- **(b) edit preservation** (5 checks): unchanged re-run is a no-op → template update rewrites when unedited → simulated user edit survives a further template update (warning logged) → UI-delete analog re-seeds fresh → corrupt record re-seeds
- **(c) idempotence** (4 checks): re-rendering the script's own output is semantically identical, no `_rN` panel-id suffix stacking, `--foxglove-userdata ''` skips seeding

**Not yet run — needs an interactive desktop + rebuilt gcs image:** live smoke test. `NUM_ROBOTS=2 airstack up gcs` should open Foxglove on **AirStack default (2 robots)** with no import dialog; edit + Save a panel, restart the container, the edit persists and startup logs report the layout has user-saved edits.

## Known limitations

- Robots are assumed named `robot_1..robot_N` (same assumption as the previous render flow); fleets with custom robot names (RFC #380) get default-named tabs — name-aware rendering is future work.
- Template updates don't propagate into a layout the user has saved edits to (by design); reset = delete the layout in Foxglove's Layouts menu.
- The store format is app-internal — the version pin plus the doc note in `docs/gcs/foxglove.md` are the guard; re-verify `studio-datastores/layouts-local` before bumping `FOXGLOVE_VERSION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
