### PR TITLE
fix(bringup): loud AUTOLAUNCH FAILED banner instead of silent tmux prompt

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ PROJECT_NAME="airstack"
 # If you've run ./airstack.sh setup, then this will auto-generate from the git commit hash every time a change is made 
 # to a Dockerfile or docker-compose.yaml file. Otherwise this can also be set explicitly to make a release version.
 # auto-generated from git commit hash
-VERSION="0.20.0-alpha.10"
+VERSION="0.20.0-alpha.11"
 # Image-tag discriminator ONLY (appears in the image tag suffix, e.g. ..._robot-x86-64_dev).
 # No Dockerfile consumes it: "prebuilt" does NOT bake the built ros_ws into the image today —
 # a real prebuilt (workspace-baked) stage is future work. Keep "dev" (mounted code, built live).

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -176,6 +176,12 @@ Feature docs deliberately cite none of these — the design sources live here:
 
 ### Changed
 
+- Container autolaunch (robot desktop/voxl/l4t and GCS) now runs through an
+  `autolaunch` shell helper instead of a bare `bws && sws && ros2 launch`
+  chain: a build failure or launch crash prints an unmissable red
+  "AUTOLAUNCH FAILED" banner in the tmux pane (mirrored to `docker logs` /
+  `airstack logs`) instead of silently returning to a prompt with the stack
+  down
 - `Dockerfile.gcs` pins the Foxglove desktop version (`FOXGLOVE_VERSION`
   build arg, currently 3.0.0) instead of installing `latest`, since the
   layout auto-load writes the app's on-disk local-layout record format

--- a/gcs/docker/.bashrc
+++ b/gcs/docker/.bashrc
@@ -60,6 +60,31 @@ function cws(){
     fi
 }
 
+# Build → source → launch, with an unmissable banner when a stage fails.
+# Used by the docker-compose AUTOLAUNCH tmux commands: a bare
+# `bws && sws && ros2 launch ...` dies silently on a build failure — the tmux
+# pane just returns to a prompt and `docker logs` shows nothing — so bringup
+# failures went unnoticed. Also fine to use interactively.
+function _autolaunch_banner(){
+    local line='!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+    printf '\n\033[1;97;41m%s\033[0m\n' "$line" "  AUTOLAUNCH FAILED on $(hostname) (GCS)" "  $1" "  Scroll up in this tmux pane (airstack connect) or 'airstack logs'" "  for the first error." "$line"
+    # Plain repeat so the message survives log processors that strip ANSI.
+    printf '%s\n' "AUTOLAUNCH FAILED: $1"
+}
+function autolaunch(){
+    if ! bws; then
+        _autolaunch_banner "colcon build (bws) failed — the stack was NOT launched"
+        return 1
+    fi
+    sws
+    ros2 launch "$@"
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        _autolaunch_banner "ros2 launch $* exited with code $rc — the stack is DOWN"
+        return $rc
+    fi
+}
+
 source /opt/ros/jazzy/setup.bash
 sws # source the ROS2 workspace by default
 

--- a/gcs/docker/gcs-base-docker-compose.yaml
+++ b/gcs/docker/gcs-base-docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       python3 /root/AirStack/gcs/foxglove_extensions/render_layout.py;
       tmux new -d -s bringup;
       if [ $$AUTOLAUNCH = 'true' ]; then
-        tmux send-keys -t bringup:0.0 'bws &&  sws; ros2 launch desktop_bringup gcs.launch.xml' ENTER;
+        tmux send-keys -t bringup:0.0 'autolaunch desktop_bringup gcs.launch.xml' ENTER;
       fi;
       sleep infinity"
     # Interactive shell

--- a/robot/docker/.bashrc
+++ b/robot/docker/.bashrc
@@ -66,6 +66,31 @@ function cws(){
     fi
 }
 
+# Build → source → launch, with an unmissable banner when a stage fails.
+# Used by the docker-compose AUTOLAUNCH tmux commands: a bare
+# `bws && sws && ros2 launch ...` dies silently on a build failure — the tmux
+# pane just returns to a prompt and `docker logs` shows nothing — so bringup
+# failures went unnoticed. Also fine to use interactively.
+function _autolaunch_banner(){
+    local line='!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+    printf '\n\033[1;97;41m%s\033[0m\n' "$line" "  AUTOLAUNCH FAILED on $(hostname) (ROBOT_NAME=${ROBOT_NAME:-unset})" "  $1" "  Scroll up in this tmux pane (airstack connect) or 'airstack logs'" "  for the first error." "$line"
+    # Plain repeat so the message survives log processors that strip ANSI.
+    printf '%s\n' "AUTOLAUNCH FAILED: $1"
+}
+function autolaunch(){
+    if ! bws; then
+        _autolaunch_banner "colcon build (bws) failed — the stack was NOT launched"
+        return 1
+    fi
+    sws
+    ros2 launch "$@"
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        _autolaunch_banner "ros2 launch $* exited with code $rc — the stack is DOWN"
+        return $rc
+    fi
+}
+
 source /opt/ros/jazzy/setup.bash
 sws # source the ROS2 workspace by default
 

--- a/robot/docker/docker-compose.yaml
+++ b/robot/docker/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
       service ssh restart;
       tmux new -d -s bringup;
       if [ $$AUTOLAUNCH == 'true' ]; then
-        tmux send-keys -t bringup:0.0 'bws && sws && ros2 launch $$LAUNCH_PACKAGE robot.launch.xml' ENTER;
+        tmux send-keys -t bringup:0.0 'autolaunch $$LAUNCH_PACKAGE robot.launch.xml' ENTER;
       fi;
       sleep infinity"
     # assumes you're connected to work internet, so creates a network to isolate from other developers on your work internet
@@ -152,7 +152,7 @@ services:
       bash -c "
       tmux new -d -s bringup;
       if [ $$AUTOLAUNCH == 'true' ]; then
-        tmux send-keys -t bringup 'bws && sws && ros2 launch $$LAUNCH_PACKAGE robot.launch.xml sim:=false' ENTER;
+        tmux send-keys -t bringup 'autolaunch $$LAUNCH_PACKAGE robot.launch.xml sim:=false' ENTER;
       fi;
       sleep infinity"
     network_mode: host
@@ -211,7 +211,7 @@ services:
       service ssh restart;
       tmux new -d -s bringup;
       if [ $$AUTOLAUNCH == 'true' ]; then
-        tmux send-keys -t bringup 'bws && sws && ros2 launch $$LAUNCH_PACKAGE robot.launch.xml sim:=false' ENTER;
+        tmux send-keys -t bringup 'autolaunch $$LAUNCH_PACKAGE robot.launch.xml sim:=false' ENTER;
       fi;
       sleep infinity"
     deploy:


### PR DESCRIPTION
## Motivation

While live-testing the Foxglove auto-layout feature (#401), the robot container's autolaunch chain `bws && sws && ros2 launch ...` died silently: one package failed to build (a machine-local stale `dpvo` leftover needing `nvcc`), the `&&` chain short-circuited, and the tmux pane just returned to a prompt. `docker logs` showed nothing. The symptom surfaced only far downstream — "Foxglove has a connection issue" (empty panels, no robot topics on the GCS domain) — and took a full debugging session to trace back to a build failure at bring-up.

The GCS variant was worse: `bws &&  sws; ros2 launch ...` — after a failed build it skipped sourcing but still ran the launch.

## What changed

Both bind-mounted `.bashrc` files (`robot/docker/.bashrc`, `gcs/docker/.bashrc`) gain an `autolaunch()` helper that runs build → source → launch and prints an unmissable banner when a stage fails:

```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  AUTOLAUNCH FAILED on <hostname> (ROBOT_NAME=robot_1)
  colcon build (bws) failed — the stack was NOT launched
  Scroll up in this tmux pane (airstack connect) or 'airstack logs'
  for the first error.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
AUTOLAUNCH FAILED: colcon build (bws) failed — the stack was NOT launched
```

Red/white ANSI banner plus a plain-text repeat (for ANSI-stripping log processors); the tmux output-mirroring hooks carry it into `docker logs` / `airstack logs`. A nonzero `ros2 launch` exit gets the same treatment ("the stack is DOWN", with the exit code).

The compose autolaunch commands now use it:

| File | Services |
|---|---|
| `robot/docker/docker-compose.yaml` | robot-desktop (and everything extending it), robot-voxl-onboard, robot-l4t |
| `gcs/docker/gcs-base-docker-compose.yaml` | gcs (also fixes the `bws && sws; ros2 launch` mis-chain that launched unsourced after a failed build) |

The zed camera service keeps its own chain — it mounts a separate bashrc and is camera-only.

Since the `.bashrc`s are bind-mounted, the change takes effect on next container start with no image rebuild. VERSION bumped 0.20.0-alpha.10 → 0.20.0-alpha.11; release-notes Changed bullet added.

## Validation

- Helper unit-tested with stubbed `bws`/`sws`/`ros2`: build failure → banner + `rc=1` + no launch attempt; launch exiting 42 → banner + `rc=42`; success → no banner, `rc=0`.
- `bash -n` on both `.bashrc`s; YAML parse on both compose files.
- Live check pending: next `airstack up` with a deliberately broken package should show the banner in `airstack logs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
