### PR TITLE
fix(ci): un-red every PR — metrics-job deps and unit-test workflow environment

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ PROJECT_NAME="airstack"
 # If you've run ./airstack.sh setup, then this will auto-generate from the git commit hash every time a change is made 
 # to a Dockerfile or docker-compose.yaml file. Otherwise this can also be set explicitly to make a release version.
 # auto-generated from git commit hash
-VERSION="0.20.0-alpha.17"
+VERSION="0.20.0-alpha.18"
 # Image-tag discriminator ONLY (appears in the image tag suffix, e.g. ..._robot-x86-64_dev).
 # No Dockerfile consumes it: "prebuilt" does NOT bake the built ros_ws into the image today —
 # a real prebuilt (workspace-baked) stage is future work. Keep "dev" (mounted code, built live).

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -505,7 +505,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install report dependencies
-        run: pip install tabulate
+        # parse_metrics.py imports the tests/harness package, so it needs the
+        # full test requirements (pyyaml et al.), not just tabulate.
+        run: pip install -r tests/requirements.txt
 
       - name: Resolve PR base branch
         if: github.event_name == 'issue_comment' || github.event_name == 'pull_request'
@@ -655,8 +657,11 @@ jobs:
 
       - name: Fail on regression
         if: steps.report.outcome == 'failure'
+        # parse_metrics.py writes report.md before exiting 1 on a regression;
+        # an uncaught crash also exits 1 but never writes the report. Require
+        # both so a parser crash cannot masquerade as a metric regression.
         run: |
-          if [ "${{ steps.report.outputs.parser_exit }}" = "1" ]; then
+          if [ "${{ steps.report.outputs.parser_exit }}" = "1" ] && [ -f report.md ]; then
             echo "::error::Metric regression detected — see the report above for details."
           else
             echo "::error::Metrics report generation failed — see the report step log."

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,6 +21,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # The tests/meta contract tests exercise `airstack up --dry-run`,
+          # whose preflight requires the PegasusSimulator submodule, and the
+          # docs-catalog contract resolves nav entries that live inside
+          # submodules (e.g. vdb_mapping_ros2/README.md).
+          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -31,6 +37,20 @@ jobs:
 
       - name: Install test dependencies
         run: python -m pip install -r tests/requirements.txt
+
+      # `airstack up --dry-run --sim isaac` preflight hard-errors without
+      # Nucleus credentials. Provision the same guest stub that
+      # module-system-tests.yml creates; hosted runners never launch Isaac.
+      - name: Create Isaac Sim omni_pass.env (preflight stub)
+        run: |
+          mkdir -p simulation/isaac-sim/docker
+          cat > simulation/isaac-sim/docker/omni_pass.env <<'EOF'
+          OMNI_USER=guest
+          OMNI_PASS=guest
+          OMNI_SERVER="omniverse://airlab-nucleus.andrew.cmu.edu/NVIDIA/Assets/Isaac/5.1"
+          ACCEPT_EULA=Y
+          OMNI_ENV_PRIVACY_CONSENT=Y
+          EOF
 
       - name: Run unit tests
         env:

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -19,6 +19,22 @@ its own notes. -->
 
 ## 0.20.0 (Unreleased)
 
+- **CI un-redded: Metrics Report and Unit Tests fixed.** Every PR had been
+  failing since ~2026-08-20 for reasons unrelated to the code under test.
+  The system-tests **Metrics Report** job installed only `tabulate`, so
+  `tests/parse_metrics.py` (which imports the `tests/harness` package)
+  crashed with `ModuleNotFoundError: No module named 'yaml'` — and the crash
+  was misreported as "Metric regression detected"; the job now installs
+  `tests/requirements.txt`, and the regression verdict additionally requires
+  a written `report.md` so a parser crash can never masquerade as a metric
+  regression. The **Unit Tests** workflow ran the `tests/meta/` contract
+  suite on a checkout with no submodules and no `omni_pass.env`, so every
+  `airstack up --dry-run --sim isaac` contract hard-failed preflight and the
+  docs-catalog contract missed the submodule-resident vdb_mapping_ros2
+  README; the workflow now checks out submodules recursively and provisions
+  the same guest `omni_pass.env` stub that `module-system-tests.yml` uses
+  (preflight itself stays strict).
+
 - **New reference stack `full_mighty` + registered `mighty` module.** The
   MIGHTY Hermite-spline local planner (MIT ACL, RA-L 2026) with its
   acl-mapping voxel world model and a NavigateTask/trajectory_controller


### PR DESCRIPTION
## Motivation

Every PR has been red since ~2026-08-20, and the failures were misattributed (most recently to OptiTrack/NatNet image-building). Triage showed two workflow-environment bugs, unrelated to any code under test:

1. **`Metrics Report` crashed on every system-tests run.** The job installed only `tabulate`, but `tests/parse_metrics.py` imports the `tests/harness` package, whose import chain does `import yaml` → `ModuleNotFoundError: No module named 'yaml'` (e.g. runs 33221960387, 32775855167). Worse, the crash's exit 1 was indistinguishable from parse_metrics' deliberate exit-1-on-regression, so every run reported the misleading **"Metric regression detected"** — even when `Run Tests` passed.

2. **`Unit Tests` failed on every PR** (the `tests/meta/` contract suite never passed in CI since landing). The workflow checked out without submodules and without `omni_pass.env`, so every `airstack up --dry-run --sim isaac` contract hard-errored in preflight (missing Nucleus credentials, empty PegasusSimulator submodule), and the docs-catalog contract couldn't find the submodule-resident `vdb_mapping_ros2/README.md`.

## What changed

- **system-tests.yml (Metrics Report job):** install `-r tests/requirements.txt` instead of bare `tabulate`; the "Fail on regression" verdict now additionally requires `report.md` to exist — parse_metrics.py writes the report before its regression exit (and writes a failure report + exit 2 for handled errors), so exit 1 without `report.md` can only be a crash and is now reported as "report generation failed".
- **unit-tests.yml:** `submodules: recursive` on checkout, plus the same guest `omni_pass.env` stub that `module-system-tests.yml` already provisions. No `airstack.sh` change — preflight stays strict; CI provisions the environment it claims to test.
- `.env` VERSION `0.20.0-alpha.17 → 0.20.0-alpha.18` + Release Notes entry.

## Validation

| Check | Repro (CI-equivalent env) | After fix |
|---|---|---|
| Metrics deps | tabulate-only venv: `python tests/parse_metrics.py --current …` → `ModuleNotFoundError: No module named 'yaml'`, exit 1, no report.md | venv from `tests/requirements.txt`: renders a well-formed report, exit 0 |
| Crash vs regression | crash exits 1 **without** report.md → previously claimed "regression" | now reported as "report generation failed" (regression requires exit 1 **and** report.md) |
| Unit contract suite | bare checkout (no submodules, no omni_pass.env): 4 representative contract tests fail exactly as in run 33221960338 | submodules + stub: 4/4 pass; full `pytest tests/ -m unit`: **402 passed, 10 skipped, 0 failed** |

This PR also unblocks #400 (orchestrator multi-repo polling), whose only failing checks are these two workflow bugs; #400 in turn unblocks `asm_optitrack` module CI, which currently starves in the runner queue (its weekly canary queued 24 h and was cancelled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
