### PR TITLE
Bump version to 0.21.0-dev.0; fix post-release sync skip

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ PROJECT_NAME="airstack"
 # If you've run ./airstack.sh setup, then this will auto-generate from the git commit hash every time a change is made 
 # to a Dockerfile or docker-compose.yaml file. Otherwise this can also be set explicitly to make a release version.
 # auto-generated from git commit hash
-VERSION="0.20.0"
+VERSION="0.21.0-dev.0"
 # Image-tag discriminator ONLY (appears in the image tag suffix, e.g. ..._robot-x86-64_dev).
 # No Dockerfile consumes it: "prebuilt" does NOT bake the built ros_ws into the image today —
 # a real prebuilt (workspace-baked) stage is future work. Keep "dev" (mounted code, built live).

--- a/.github/workflows/sync-develop-from-main.yaml
+++ b/.github/workflows/sync-develop-from-main.yaml
@@ -42,9 +42,14 @@ jobs:
             git -c core.editor=true commit --no-edit
           fi
 
-          # If develop already contained everything main has, nothing to do.
-          if git diff --quiet origin/develop..HEAD; then
-            echo "develop already up to date with main; nothing to sync."
+          # Skip only when main is already in develop's ancestry. A tree
+          # diff is the wrong check here: right after a release, the merge
+          # result is content-identical to develop, but the merge commit
+          # must still be pushed (it advances the develop↔main merge base,
+          # preventing spurious conflicts on the next release PR) and the
+          # VERSION roll-forward below must still happen.
+          if git merge-base --is-ancestor origin/main origin/develop; then
+            echo "main is already an ancestor of develop; nothing to sync."
             echo "SKIP=true" >> $GITHUB_ENV
           fi
 

--- a/airstack.yaml
+++ b/airstack.yaml
@@ -18,7 +18,7 @@
 #     file is future work — launch behavior without --fleet is unchanged).
 
 # Informational: the trunk release this checkout tracks (see `.env` VERSION).
-release: "0.20.0"
+release: "0.21.0-dev"
 
 # The fleet this checkout flies (config/fleets/*.yaml — RFC #380 §2).
 # sim_one_default == today's defaults: one quad_default on full_default.

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -19,7 +19,12 @@ its own notes. -->
 
 ## 0.21.0 (Unreleased)
 
-- Nothing yet.
+- **Fixed: post-release main→develop sync no longer skips.** The
+  `sync-develop-from-main` workflow skipped whenever the merge result was
+  content-identical to `develop` — exactly the situation right after a
+  release — so it never pushed the ancestry-advancing merge commit or
+  rolled `develop`'s VERSION forward. It now skips only when `main` is
+  already an ancestor of `develop`.
 
 ## 0.20.0 — 2026-08-29
 


### PR DESCRIPTION
Post-release follow-up to 0.20.0 (released: https://github.com/castacks/AirStack/releases/tag/0.20.0):

- **VERSION → `0.21.0-dev.0`** — first version on the new `-dev.N` pre-release line (replacing `-alpha.N`). Develop is otherwise code-identical to the 0.20.0 release. `airstack.yaml`'s informational `release:` field → `"0.21.0-dev"`.
- **Fix `sync-develop-from-main` skip logic** — it skipped whenever the merge result was content-identical to develop, which is exactly the situation right after a release, so it never pushed the ancestry-advancing merge commit or rolled develop's VERSION forward (this release's sync run skipped exactly this way; #411 and this PR are the manual stand-ins). It now skips only when main is already an ancestor of develop, so future releases get the merge-base advance and the `-dev.0` roll-forward automatically.

Squash-merging this one is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)