### PR TITLE
hotfix(ci): make the fixed post-release sync live on main

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ PROJECT_NAME="airstack"
 # If you've run ./airstack.sh setup, then this will auto-generate from the git commit hash every time a change is made 
 # to a Dockerfile or docker-compose.yaml file. Otherwise this can also be set explicitly to make a release version.
 # auto-generated from git commit hash
-VERSION="0.20.0"
+VERSION="0.20.1"
 # Image-tag discriminator ONLY (appears in the image tag suffix, e.g. ..._robot-x86-64_dev).
 # No Dockerfile consumes it: "prebuilt" does NOT bake the built ros_ws into the image today —
 # a real prebuilt (workspace-baked) stage is future work. Keep "dev" (mounted code, built live).

--- a/.github/workflows/sync-develop-from-main.yaml
+++ b/.github/workflows/sync-develop-from-main.yaml
@@ -42,9 +42,14 @@ jobs:
             git -c core.editor=true commit --no-edit
           fi
 
-          # If develop already contained everything main has, nothing to do.
-          if git diff --quiet origin/develop..HEAD; then
-            echo "develop already up to date with main; nothing to sync."
+          # Skip only when main is already in develop's ancestry. A tree
+          # diff is the wrong check here: right after a release, the merge
+          # result is content-identical to develop, but the merge commit
+          # must still be pushed (it advances the develop↔main merge base,
+          # preventing spurious conflicts on the next release PR) and the
+          # VERSION roll-forward below must still happen.
+          if git merge-base --is-ancestor origin/main origin/develop; then
+            echo "main is already an ancestor of develop; nothing to sync."
             echo "SKIP=true" >> $GITHUB_ENV
           fi
 


### PR DESCRIPTION
Backports the `sync-develop-from-main` skip-logic fix from develop (#412) onto main, so it's live **before** the 0.21.0 release — push-triggered workflows run from main's copy of the workflow file, so without this the fix wouldn't take effect until the release after next.

- `.github/workflows/sync-develop-from-main.yaml`: byte-identical copy of develop's fixed version (skip only when main is already an ancestor of develop, instead of the tree-diff check that fired right after every release).
- `.env`: `0.20.0` → `0.20.1` (CI-only change; the bump is required by the version gate). develop stays strictly greater at `0.21.0-dev.0`.

Deliberately excludes release-notes edits so the automatic sync merge back into develop cannot conflict (the workflow auto-resolves `.env` by keeping develop's side; the workflow file matches develop's exactly).

**Squash-merge is fine** (satisfies linear history). Merging this will trigger the first live run of the fixed sync: expect it to merge main into develop and auto-bump develop to `0.21.0-dev.1` (hotfix path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)