### PR TITLE
hotfix(docs): Harbor registry is public — drop docker login from pull instructions

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ PROJECT_NAME="airstack"
 # If you've run ./airstack.sh setup, then this will auto-generate from the git commit hash every time a change is made 
 # to a Dockerfile or docker-compose.yaml file. Otherwise this can also be set explicitly to make a release version.
 # auto-generated from git commit hash
-VERSION="0.20.4"
+VERSION="0.20.5"
 # Image-tag discriminator ONLY (appears in the image tag suffix, e.g. ..._robot-x86-64_dev).
 # No Dockerfile consumes it: "prebuilt" does NOT bake the built ros_ws into the image today —
 # a real prebuilt (workspace-baked) stage is future work. Keep "dev" (mounted code, built live).

--- a/docs/development/beginner/airstack-cli/docker_usage.md
+++ b/docs/development/beginner/airstack-cli/docker_usage.md
@@ -22,19 +22,18 @@ docker compose build     # Build from scratch
 
 ## Pull Images
 
-To use the AirLab docker registry:
+The AirLab docker registry (`airlab-docker.andrew.cmu.edu`) is public — no `docker login` is needed to pull:
 
 ```bash
 cd AirStack/
-docker login airlab-docker.andrew.cmu.edu
-## <Enter your andrew id (without @andrew.cmu.edu)>
-## <Enter your andrew password>
 
 ## Pull the images in the docker compose file
 docker compose pull
 ```
 
 The available image tags are listed [here](https://airlab-docker.andrew.cmu.edu/harbor/projects/2/repositories/airstack/artifacts-tab).
+
+Pushing images still requires an AirLab account (`docker login airlab-docker.andrew.cmu.edu` first).
 
 ## Build Images
 

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -15,7 +15,7 @@
     We'd really appreciate your feedback and contributions to improve this project for everyone! 
     Please join our #airstack channel on Slack to contribute or ask questions.
 
-    You will need to have an account with AirLab to access the AirLab Docker registry, Nucleus server, and other resources.
+    The AirLab Docker registry is public, so anyone can pull the Docker images without an account. You will need an account with AirLab to push images and to access the Nucleus server and other internal resources.
     The API and functionality are not stable and are subject to change. 
 
 
@@ -49,13 +49,10 @@ source ~/.bashrc  # OR ~/.zshrc. applies settings to enable `airstack` command
 Now you have two options on how to proceed. You can build the docker image from scratch or pull the existing image on the airlab docker registry. Building the image from scratch can be useful if you would like to add new dependencies or add new custom functionality. For most users just pulling the existing image will be more conveninent and fast since it doesn't require access to the Nvidia registry.
 
 <details open> <summary>Option 1: Pull From the Airlab Docker Registry (Preferred)</summary>
-To use the AirLab Docker registry do the following
+The AirLab Docker registry (<code>airlab-docker.andrew.cmu.edu</code>) is public — no account or <code>docker login</code> is needed to pull.
 
 ```bash
 cd AirStack/
-docker login airlab-docker.andrew.cmu.edu
-## <Enter your andrew id (without @andrew.cmu.edu)>
-## <Enter your andrew password>
 
 ## Pull the images in the docker compose file
 airstack images pull
@@ -76,9 +73,10 @@ The images will be pulled from the server automatically. This might take a while
     airstack images build
     ```
 
-If you have permission you can push updated images to the docker server.
+If you have permission you can push updated images to the docker server. Pushing (unlike pulling) requires logging in with your AirLab account first.
 
 ```bash
+docker login airlab-docker.andrew.cmu.edu
 airstack images push
 ```
 

--- a/docs/simulation/isaac_sim/container_workflows.md
+++ b/docs/simulation/isaac_sim/container_workflows.md
@@ -197,10 +197,7 @@ ls $HOME/docker/isaac-sim/logs/
 ### Pulling Pre-built Images
 
 ```bash
-# Login to AirLab registry
-docker login airlab-docker.andrew.cmu.edu
-
-# Pull Isaac Sim image
+# Pull Isaac Sim image (the AirLab registry is public — no login needed)
 docker compose -f simulation/isaac-sim/docker/docker-compose.yaml pull
 ```
 

--- a/docs/simulation/ms-airsim/docker.md
+++ b/docs/simulation/ms-airsim/docker.md
@@ -239,10 +239,7 @@ airstack up --sim airsim --robots 3
 ### Pulling Pre-built Images
 
 ```bash
-# Login to AirLab registry
-docker login airlab-docker.andrew.cmu.edu
-
-# Pull image
+# Pull image (the AirLab registry is public — no login needed)
 docker compose -f simulation/ms-airsim/docker/docker-compose.yaml pull
 ```
 


### PR DESCRIPTION
## Summary

The `airstack` project on the AirLab Harbor registry (`airlab-docker.andrew.cmu.edu`) is now **public**, so images can be pulled without an account. This PR updates every user-facing pull instruction that still told readers to `docker login` with an Andrew ID.

**Verified anonymously** (no credentials anywhere in the chain):
- Harbor API reports `"public": "true"` for the project
- Anonymous registry token grant succeeds
- Tag list (294 tags), OCI index, per-arch manifest, and config blob all fetch with the anonymous token — the same data path `docker pull` uses

## Changes

- `docs/getting_started/index.md` — removed the login step from Option 1 (pull); reworded the alpha warning (account needed only for push / Nucleus / internal resources); added `docker login` before `airstack images push` in Option 2
- `docs/development/beginner/airstack-cli/docker_usage.md` — pull section no longer requires login; push note added
- `docs/simulation/isaac_sim/container_workflows.md` — dropped login from image pull snippet
- `docs/simulation/ms-airsim/docker.md` — dropped login from image pull snippet
- `.env` — VERSION 0.20.4 → 0.20.5 (version gate; docs-only, so docker-build should retag rather than rebuild)

- `docs/release_notes/index.md` — new dated `## 0.20.5` section for this hotfix, plus backfilled dated sections for hotfixes 0.20.1–0.20.4 (they landed without notes)
- `.agents/skills/bump-version-and-release/SKILL.md` + `AGENTS.md` — codified the rule: every hotfix on `main` (docs/CI-only included) adds its own dated `## X.Y.Z — YYYY-MM-DD` patch-notes section

Left unchanged: OSMO credential setup docs and CI cache docs — those cover credentialed push/CI flows that still require login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
