### PR TITLE
hotfix(docs): dated release-notes sections for 0.20.1–0.20.5; require them for all hotfixes

### DIFF
--- a/.agents/skills/bump-version-and-release/SKILL.md
+++ b/.agents/skills/bump-version-and-release/SKILL.md
@@ -136,6 +136,13 @@ single source). Add your bullets under the current version's `##` section
 suffix), stamp that section's heading with the release date and open a fresh
 `## <next-version> (Unreleased)` section above it.
 
+**Hotfixes on `main` are not exempt.** Every hotfix patch bump (e.g.
+`0.20.4 → 0.20.5`) must add its own dated section
+`## <VERSION> — <YYYY-MM-DD>` with the patch notes — even for docs-only or
+CI-only hotfixes. The MAJOR.MINOR docs build renders all of that line's
+patch sections together, so a hotfix without a section is invisible
+history on the published site.
+
 ### 4. Verify locally
 
 ```bash
@@ -218,6 +225,7 @@ Rules:
 - Use the H3 sections **Added**, **Changed**, **Fixed**, **Removed**, **Deprecated**, **Security** as needed; a release may also open with a short narrative and breaking-changes subsection.
 - For pre-release bumps (`-dev.N`, `-beta.N`, `-rc.N`), keep your bullets under the current `(Unreleased)` section. Do not create a section per dev bump.
 - For a release bump (no suffix), retitle the section to `## <VERSION> — <YYYY-MM-DD>` and open a fresh `## <next-version> (Unreleased)` above it.
+- For a **hotfix on `main`** (patch bump on an already-released line, e.g. `0.20.4 → 0.20.5`), always add a **new dated section** `## <VERSION> — <YYYY-MM-DD>` with the patch notes, placed above the previous patch's section. This applies to every hotfix, including docs-only and CI-only ones.
 - Write user-facing prose, not commit log dumps. Mention new modules, breaking changes, and notable behavior shifts, with what changed FROM what.
 
 ## Common Pitfalls
@@ -239,7 +247,7 @@ For a normal feature/fix PR:
 1. [ ] Confirm the PR changes Docker image content or otherwise warrants a bump (see "When to Use").
 2. [ ] Pick the bump type (see "Choosing the Bump Type").
 3. [ ] Edit `/.env` — change only the `VERSION=` line.
-4. [ ] Add your bullets to `docs/release_notes/index.md` under the current `(Unreleased)` version section.
+4. [ ] Add your bullets to `docs/release_notes/index.md` — under the current `(Unreleased)` section for pre-release bumps, or as a new dated `## <VERSION> — <YYYY-MM-DD>` section for a hotfix on `main`.
 5. [ ] `airstack version` and `git diff .env docs/release_notes/index.md` to verify.
 6. [ ] Commit (`Bump version to <new>` is the established style).
 7. [ ] Push and open the PR. Confirm `Check VERSION Increment` passes green.

--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ PROJECT_NAME="airstack"
 # If you've run ./airstack.sh setup, then this will auto-generate from the git commit hash every time a change is made 
 # to a Dockerfile or docker-compose.yaml file. Otherwise this can also be set explicitly to make a release version.
 # auto-generated from git commit hash
-VERSION="0.20.5"
+VERSION="0.20.6"
 # Image-tag discriminator ONLY (appears in the image tag suffix, e.g. ..._robot-x86-64_dev).
 # No Dockerfile consumes it: "prebuilt" does NOT bake the built ros_ws into the image today —
 # a real prebuilt (workspace-baked) stage is future work. Keep "dev" (mounted code, built live).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ For detailed step-by-step instructions, refer to the **`.agents/skills/`** direc
 | [add-behavior-tree-node](.agents/skills/add-behavior-tree-node) | Creating behavior tree nodes |
 | [use-airstack-cli](.agents/skills/use-airstack-cli) | Using the `airstack` CLI and the non-interactive `docker exec` pattern |
 | [configure-multi-robot](.agents/skills/configure-multi-robot) | Setting up multiple robots — fleet files (`--fleet`, heterogeneous + split placement) and legacy NUM_ROBOTS, ROBOT_NAME namespacing, ROS_DOMAIN_ID isolation |
-| [bump-version-and-release](.agents/skills/bump-version-and-release) | Bumping `.env` VERSION and recording the change in the versioned Release Notes (docs/release_notes/index.md) before merge to clear the version-check gate |
+| [bump-version-and-release](.agents/skills/bump-version-and-release) | Bumping `.env` VERSION and recording the change in the versioned Release Notes (docs/release_notes/index.md) before merge to clear the version-check gate — every hotfix on `main` must add its own dated `## X.Y.Z — YYYY-MM-DD` patch-notes section |
 | [capture-discovered-knowledge](.agents/skills/capture-discovered-knowledge) | After long context-discovery / surprising findings, persist to AGENTS.md or a new skill so the next agent doesn't redo the work |
 | [use-feature-notebook](.agents/skills/use-feature-notebook) | At the start of EVERY feature implementation: create `notebook/NNN-feature-slug/design_spec.md`, store test artifacts under `results/`, write `results/results_summary.md`, and populate the PR from it |
 

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -21,6 +21,44 @@ its own notes. -->
 
 - Nothing yet.
 
+## 0.20.5 — 2026-08-29
+
+- **Docker images are publicly pullable.** The AirLab Harbor registry
+  project (`airlab-docker.andrew.cmu.edu/airstack`) is now public: pulling
+  the AirStack images no longer requires an AirLab account or
+  `docker login`. Pull instructions across the docs (Getting Started, CLI
+  docker usage, Isaac Sim / MS-AirSim image management) were updated
+  accordingly. Pushing images still requires logging in with an AirLab
+  account.
+
+## 0.20.4 — 2026-08-29
+
+- **Docs site root pinned to the release slug.** docs.theairlab.org now
+  redirects to the current MAJOR.MINOR slug (`/0.20/`) instead of the
+  moving `/main/` alias, so the URLs readers land on and copy stay valid
+  across future releases.
+
+## 0.20.3 — 2026-08-29
+
+- **Stable docs alias renamed `latest` → `main`**, restoring pre-0.20
+  bookmark URLs. The three docs deploy workflows now share a concurrency
+  group so concurrent gh-pages pushes no longer race.
+
+## 0.20.2 — 2026-08-29
+
+- **Docs versions use MAJOR.MINOR slugs.** The version selector no longer
+  shows the same release twice: docs deploy under slugs like `/0.20/`
+  titled with the full patch version, hotfixes republish the slug in
+  place, and this Release Notes page renders every section sharing the
+  built version's MAJOR.MINOR.
+
+## 0.20.1 — 2026-08-29
+
+- **Fixed the post-release main→develop sync** skipping when the merge
+  result was content-identical to develop — the ancestry-advancing merge
+  commit was never pushed, so develop's VERSION never rolled forward
+  after a release.
+
 ## 0.20.0 — 2026-08-29
 
 - **Pre-release versioning terminology: `-alpha.N` → `-dev.N`.** The

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -21,6 +21,15 @@ its own notes. -->
 
 - Nothing yet.
 
+## 0.20.6 — 2026-08-29
+
+- **Release notes now carry a dated section per hotfix.** Added the
+  missing sections for hotfixes 0.20.1–0.20.5 and codified the rule in
+  the `bump-version-and-release` skill and AGENTS.md: every hotfix on
+  `main` — docs-only and CI-only included — adds its own dated
+  `## X.Y.Z — YYYY-MM-DD` patch-notes section, since the MAJOR.MINOR
+  docs build renders all of a line's patch sections together.
+
 ## 0.20.5 — 2026-08-29
 
 - **Docker images are publicly pullable.** The AirLab Harbor registry


### PR DESCRIPTION
## Summary

Follow-up to #417 — that PR merged before its second commit (release notes + hotfix rule) was pushed, so those changes never reached `main`. This PR carries them, rebased onto the merged main.

## Changes

- `docs/release_notes/index.md` — dated patch-notes sections for **0.20.1 through 0.20.6** (none of the 0.20.x hotfixes had one; the release-notes build hook renders every section sharing the built MAJOR.MINOR, so the published /0.20/ page was silently missing all hotfix history)
- `.agents/skills/bump-version-and-release/SKILL.md` — codified the rule in the *Update the Release Notes* step, the *Release Notes Conventions* rules, and the release checklist: every hotfix on `main` (docs-only and CI-only included) adds its own dated `## X.Y.Z — YYYY-MM-DD` section
- `AGENTS.md` — skill-table row for `bump-version-and-release` now states the requirement
- `.env` — VERSION 0.20.5 → 0.20.6 (gate; docs-only, publish should retag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)