### PR TITLE
chore(catalog): sync committed module catalog from the registry

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ PROJECT_NAME="airstack"
 # If you've run ./airstack.sh setup, then this will auto-generate from the git commit hash every time a change is made 
 # to a Dockerfile or docker-compose.yaml file. Otherwise this can also be set explicitly to make a release version.
 # auto-generated from git commit hash
-VERSION="0.21.0-dev.9"
+VERSION="0.21.0-dev.10"
 # Image-tag discriminator ONLY (appears in the image tag suffix, e.g. ..._robot-x86-64_dev).
 # No Dockerfile consumes it: "prebuilt" does NOT bake the built ros_ws into the image today —
 # a real prebuilt (workspace-baked) stage is future work. Keep "dev" (mounted code, built live).

--- a/docs/modules/mighty.md
+++ b/docs/modules/mighty.md
@@ -12,7 +12,7 @@
 | Type | `ros_package` |
 | Maintainer | ajong@andrew.cmu.edu |
 | License | BSD-3-Clause-Clear |
-| Registered ref | [`v0.1.1`](https://github.com/castacks/asm_mighty/tree/v0.1.1) |
+| Registered ref | [`v0.1.3`](https://github.com/castacks/asm_mighty/tree/v0.1.3) |
 | Declared compat | `>=0.20.0-alpha.16 <0.21.0` |
 | Registry entry | [modules/mighty.yaml](https://github.com/castacks/airstack-modules-index/blob/main/modules/mighty.yaml) |
 
@@ -21,7 +21,7 @@
 From an AirStack checkout ([AirStack Modules guide](../development/modules.md)):
 
 ```bash
-airstack module add https://github.com/castacks/asm_mighty --version v0.1.1
+airstack module add https://github.com/castacks/asm_mighty --version v0.1.3
 airstack up
 ```
 
@@ -42,7 +42,7 @@ matrix, read the declaration as intent.
 
 ## Documentation
 
-- [Module README on GitHub @ `v0.1.1`](https://github.com/castacks/asm_mighty/blob/v0.1.1/README.md)
+- [Module README on GitHub @ `v0.1.3`](https://github.com/castacks/asm_mighty/blob/v0.1.3/README.md)
 - *The module repo was not fetched when this page was generated — the*
   *links above go to GitHub at the registered ref (failure isolation:*
   *an unreachable module repo never fails the docs deploy).*
@@ -53,4 +53,4 @@ matrix, read the declaration as intent.
 
 ## Registry notes
 
-> Repo is PRIVATE until the AirStack agent study (ICRA 2027 paper, Sec. VI-C) concludes, then flips public — until then the repo/README links 404 for non-members. v0.1.1 is code-identical to v0.1.0 (README-only delta); v0.1.0 was validated end-to-end on Isaac Sim: 44/44 vendored gtests, synthetic smoke harness, empty-world NavigateTask flight, 7/7 practice pillar-field traversals, and 5/5 judged obstacle-route flights (min clearances 1.59–1.65 m vs a 1.0 m gate). Wrapper packages are BSD-3-Clause-Clear; vendored upstream packages (mighty, DecompROS2, acl-mapping) keep their own permissive licenses — see the module's VENDORED.md. Consumed by trunk reference stack full_mighty.
+> Public repo. v0.1.0 was validated end-to-end on Isaac Sim: 44/44 vendored gtests, synthetic smoke harness, empty-world NavigateTask flight, 7/7 practice pillar-field traversals, and 5/5 judged obstacle-route flights (min clearances 1.59–1.65 m vs a 1.0 m gate); v0.1.1 is code-identical (README delta). v0.1.2 fixes the bridge for AirStack 0.20.x — takeoff leaves the trajectory controller in ROBOT_POSE, where trajectory_override is merged but never flown, so v0.1.1 commits one trajectory and idles ("never replans"); the bridge now sets TRACK, bounds/preempts NavigateTask goals, drops stale global_plan routes and turns to the goal yaw on arrival (MIGHTY drops the goal orientation). v0.1.3 adds launch args for the mapper->planner grid seam and the altitude band (defaults unchanged). The v0.1.2 fixes were verified in closed-loop Isaac flights; the judged campaign was not re-run. Wrapper packages are BSD-3-Clause-Clear; vendored upstream packages (mighty, DecompROS2, acl-mapping) keep their own permissive licenses — see the module's VENDORED.md. Consumed by trunk reference stack full_mighty (pin v0.1.3 or newer).

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -19,6 +19,8 @@ its own notes. -->
 
 ## 0.21.0 (Unreleased)
 
+- Module catalog synced from the registry (`sync-modules-index`): `full_mighty`, `mighty`.
+
 - **Fixed: post-release main→develop sync no longer skips.** The
   `sync-develop-from-main` workflow skipped whenever the merge result was
   content-identical to `develop` — exactly the situation right after a

--- a/tests/meta/fixtures/modules_index/modules/mighty.yaml
+++ b/tests/meta/fixtures/modules_index/modules/mighty.yaml
@@ -11,16 +11,22 @@ description: >-
 maintainer: ajong@andrew.cmu.edu   # Andrew Jong
 license: BSD-3-Clause-Clear
 type: ros_package
-registered_ref: v0.1.1
+registered_ref: v0.1.3
 airstack_compat: ">=0.20.0-alpha.16 <0.21.0"   # DECLARED (from module.yaml)
 notes: >-
-  Repo is PRIVATE until the AirStack agent study (ICRA 2027 paper, Sec. VI-C)
-  concludes, then flips public — until then the repo/README links 404 for
-  non-members. v0.1.1 is code-identical to v0.1.0 (README-only delta); v0.1.0
-  was validated end-to-end on Isaac Sim: 44/44 vendored gtests, synthetic
-  smoke harness, empty-world NavigateTask flight, 7/7 practice pillar-field
-  traversals, and 5/5 judged obstacle-route flights (min clearances
-  1.59–1.65 m vs a 1.0 m gate). Wrapper packages are BSD-3-Clause-Clear;
-  vendored upstream packages (mighty, DecompROS2, acl-mapping) keep their own
-  permissive licenses — see the module's VENDORED.md. Consumed by trunk
-  reference stack full_mighty.
+  Public repo. v0.1.0 was validated end-to-end on Isaac Sim: 44/44 vendored
+  gtests, synthetic smoke harness, empty-world NavigateTask flight, 7/7
+  practice pillar-field traversals, and 5/5 judged obstacle-route flights (min
+  clearances 1.59–1.65 m vs a 1.0 m gate); v0.1.1 is code-identical (README
+  delta). v0.1.2 fixes the bridge for AirStack 0.20.x — takeoff leaves the
+  trajectory controller in ROBOT_POSE, where trajectory_override is merged but
+  never flown, so v0.1.1 commits one trajectory and idles ("never replans");
+  the bridge now sets TRACK, bounds/preempts NavigateTask goals, drops stale
+  global_plan routes and turns to the goal yaw on arrival (MIGHTY drops the
+  goal orientation). v0.1.3 adds launch args for the mapper->planner grid seam
+  and the altitude band (defaults unchanged). The v0.1.2 fixes were verified in
+  closed-loop Isaac flights; the judged campaign was not re-run. Wrapper
+  packages are BSD-3-Clause-Clear; vendored upstream packages (mighty,
+  DecompROS2, acl-mapping) keep their own permissive licenses — see the
+  module's VENDORED.md. Consumed by trunk reference stack full_mighty (pin
+  v0.1.3 or newer).

--- a/tests/meta/fixtures/modules_index/stacks/full_mighty.yaml
+++ b/tests/meta/fixtures/modules_index/stacks/full_mighty.yaml
@@ -12,6 +12,6 @@ wiring: stacks/full_mighty/wiring.md           # docs site embeds the CI-generat
 notes: >-
   The module-swap demonstration for the modular architecture: the only
   difference vs full_default is one include in launch/stack.launch.xml plus
-  the asm_mighty pin in modules.repos (registry: modules/mighty.yaml — repo
-  private until the agent study concludes). wiring.md is pending the stack's
-  first validated wiring-snapshot run.
+  the asm_mighty pin in modules.repos (registry: modules/mighty.yaml; pin
+  v0.1.3 or newer — earlier bridges hang on 0.20.x, see the module notes).
+  wiring.md is pending the stack's first validated wiring-snapshot run.


### PR DESCRIPTION
Automated trunk half of module registration (see the extract-module skill): mirrors the live [airstack-modules-index](https://github.com/castacks/airstack-modules-index) into tests/meta/fixtures/modules_index/ and regenerates the committed docs/modules pages with tools/gen_docs_catalog.py. VERSION is bumped only to satisfy the check-version-increment gate (docs-only change; publish will retag, not rebuild).

Everything here is deterministic output of already-reviewed registry entries.

If CI checks did not start on this PR, it was opened with the fallback workflow token (REGISTRY_SYNC_TOKEN secret not configured) — close and reopen it to trigger them. The branch is force-refreshed from develop on each run, so a stale VERSION bump heals itself on the next run.

Workflow: sync-modules-index (https://github.com/castacks/AirStack/actions/runs/34551486866)