### PR TITLE
docs(modules): document sidecar services in compose fragments (follow-up to #426)

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ PROJECT_NAME="airstack"
 # If you've run ./airstack.sh setup, then this will auto-generate from the git commit hash every time a change is made 
 # to a Dockerfile or docker-compose.yaml file. Otherwise this can also be set explicitly to make a release version.
 # auto-generated from git commit hash
-VERSION="0.21.0-dev.14"
+VERSION="0.21.0-dev.15"
 # Image-tag discriminator ONLY (appears in the image tag suffix, e.g. ..._robot-x86-64_dev).
 # No Dockerfile consumes it: "prebuilt" does NOT bake the built ros_ws into the image today —
 # a real prebuilt (workspace-baked) stage is future work. Keep "dev" (mounted code, built live).

--- a/docs/development/modules.md
+++ b/docs/development/modules.md
@@ -124,10 +124,15 @@ Placement is driven by the manifest's `type` and `targets`:
   `sys.path.insert(0, os.environ.get("AIRSTACK_LAUNCH_SCRIPTS_DIR", "/isaac-sim/AirStack/simulation/isaac-sim/launch_scripts"))`
   instead of baking in the mount path.
 - **`compose:` fragments** (any type) — the fragment's `services:` are merged
-  into the generated file, with relative host paths rewritten to absolute
-  (compose resolves relative bind sources against different bases depending on
-  how files are merged; the generated file is machine-local and regenerated on
-  every sync, so absolute is the unambiguous choice).
+  into the generated file, with relative host paths rewritten to absolute:
+  bind-mount sources, `build.context` / `build.dockerfile`, and `env_file`
+  entries (compose resolves relative paths against different bases depending
+  on how files are merged; the generated file is machine-local and regenerated
+  on every sync, so absolute is the unambiguous choice). A fragment may
+  therefore declare a whole **sidecar service** with its own `build:` section
+  — a second container next to the robot, built on first `airstack up` — which
+  is how the `raven` module runs its GPU-heavy RayFronts mapper on the robot's
+  DDS domain without touching the robot image.
 - **`data`** — no overlay action yet (asset fetching lands with a later phase).
 
 Everything is idempotent: re-running `sync` converges, `module remove` (or


### PR DESCRIPTION
Follow-up to #426. Adds the paragraph in `docs/development/modules.md` describing that a module compose fragment may declare a sidecar service with its own `build:` section (the overlay absolutizes `build.context` / `build.dockerfile` / `env_file`), as the `raven` module does for its RayFronts container. The matching note in the `create-module` skill already landed with #426; this paragraph had been written on the wrong checkout.

Docs-only; VERSION bumped for the increment gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)